### PR TITLE
fix cpu2wiotp error and build improvements

### DIFF
--- a/edge/wiotp/cpu2wiotp/Dockerfile.arm
+++ b/edge/wiotp/cpu2wiotp/Dockerfile.arm
@@ -1,4 +1,5 @@
 FROM armhf/alpine:latest
+ENV ARCH=armhf
 RUN apk --no-cache --update add curl mosquitto-clients
 COPY *.sh /
 COPY *.pem /

--- a/edge/wiotp/cpu2wiotp/Dockerfile.x86
+++ b/edge/wiotp/cpu2wiotp/Dockerfile.x86
@@ -1,4 +1,5 @@
 FROM alpine:latest
+ENV ARCH=x86
 RUN apk --no-cache --update add curl mosquitto-clients
 COPY *.sh /
 COPY *.pem /

--- a/edge/wiotp/cpu2wiotp/Makefile
+++ b/edge/wiotp/cpu2wiotp/Makefile
@@ -5,9 +5,11 @@ all:
 
 # Get the 3-character prefix of the local host architecture ("arm" or "x86")
 SYSTEM_ARCH := $(shell uname -m | sed 's/\(...\).*/\1/')
+# To build for an arch different from the current system, set this env var to arm or x86 before running make
+ARCH ?= $(SYSTEM_ARCH)
 
 build:
-	docker build -t cpu2wiotp -f ./Dockerfile.$(SYSTEM_ARCH) .
+	docker build -t cpu2wiotp -f ./Dockerfile.$(ARCH) .
 
 dev:
 	-docker stop cpu2wiotp
@@ -22,8 +24,18 @@ run:
 check:
 	curl -s localhost:8347/v1/cpu | jq
 
+# These variables can be overridden from the environment
+CPU2WIOTP_VERSION ?= 1.1.4
+CPU2WIOTP_DOCKER_NAME ?= openhorizon/example_wl_$(ARCH)_cpu2wiotp
+
+# To publish you must have write access to the docker hub openhorizon user
+publish:
+	docker build -t $(CPU2WIOTP_DOCKER_NAME):$(CPU2WIOTP_VERSION) -f ./Dockerfile.$(ARCH) .
+	docker push $(CPU2WIOTP_DOCKER_NAME):$(CPU2WIOTP_VERSION)
+
 clean:
 	-docker stop cpu2wiotp
 	-docker rm cpu2wiotp
 	-docker rmi cpu2wiotp
 
+.PHONY: all build dev run check publish clean

--- a/edge/wiotp/cpu2wiotp/horizon/cpu2wiotp-amd64.json
+++ b/edge/wiotp/cpu2wiotp/horizon/cpu2wiotp-amd64.json
@@ -3,7 +3,7 @@
   "description": "Sample Horizon workload that repeatedly reads the CPU load and sends it to WIoTP",
   "public": true,
   "workloadUrl": "https://internetofthings.ibmcloud.com/workloads/cpu2wiotp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "arch": "amd64",
   "downloadUrl": "not used yet",
   "apiSpec": [
@@ -33,7 +33,7 @@
   ],
   "workloads": [
     {
-      "deployment": "{\"services\":{\"cpu2wiotp\":{\"image\":\"openhorizon/example_wl_x86_cpu2wiotp:1.1.3\",\"environment\":[\"WIOTP_DOMAIN=internetofthings.ibmcloud.com\"]}}}",
+      "deployment": "{\"services\":{\"cpu2wiotp\":{\"image\":\"openhorizon/example_wl_x86_cpu2wiotp:1.1.4\",\"environment\":[\"WIOTP_DOMAIN=internetofthings.ibmcloud.com\"]}}}",
       "deployment_signature": "",
       "torrent": "{\"url\":\"\",\"signature\":\"\"}"
     }

--- a/edge/wiotp/cpu2wiotp/horizon/cpu2wiotp-arm.json
+++ b/edge/wiotp/cpu2wiotp/horizon/cpu2wiotp-arm.json
@@ -3,7 +3,7 @@
   "description": "Sample Horizon workload that repeatedly reads the CPU load and sends it to WIoTP",
   "public": true,
   "workloadUrl": "https://internetofthings.ibmcloud.com/workloads/cpu2wiotp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "arch": "arm",
   "downloadUrl": "not used yet",
   "apiSpec": [
@@ -33,7 +33,7 @@
   ],
   "workloads": [
     {
-      "deployment": "{\"services\":{\"cpu2wiotp\":{\"image\":\"openhorizon/example_wl_arm_cpu2wiotp:1.1.3\",\"environment\":[\"WIOTP_DOMAIN=internetofthings.ibmcloud.com\"]}}}",
+      "deployment": "{\"services\":{\"cpu2wiotp\":{\"image\":\"openhorizon/example_wl_arm_cpu2wiotp:1.1.4\",\"environment\":[\"WIOTP_DOMAIN=internetofthings.ibmcloud.com\"]}}}",
       "deployment_signature": "",
       "torrent": "{\"url\":\"\",\"signature\":\"\"}"
     }

--- a/edge/wiotp/cpu2wiotp/horizon/pattern/cpu2wiotp.json
+++ b/edge/wiotp/cpu2wiotp/horizon/pattern/cpu2wiotp.json
@@ -9,7 +9,7 @@
       "workloadArch": "amd64",
       "workloadVersions": [
         {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "deployment_overrides": "",
           "deployment_overrides_signature": "",
           "priority": {},
@@ -27,7 +27,7 @@
       "workloadArch": "arm",
       "workloadVersions": [
         {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "deployment_overrides": "",
           "deployment_overrides_signature": "",
           "priority": {},


### PR DESCRIPTION
- added `-S -w %{http_code}` to curl cmd to get errors
- added checking of http code
- protected some of the mosquitto_pub args in quotes
- added `make publish` target, since we aren't supposed to tag docker images right now (current limitation in mike's docker pull code
- added building for different arch
- updated cpu2wiotp workload and pattern def files to point to version 1.1.4 