### PR TITLE
Change to amd64

### DIFF
--- a/edge/services/cpu_percent/Dockerfile.amd64
+++ b/edge/services/cpu_percent/Dockerfile.amd64
@@ -1,5 +1,5 @@
 FROM alpine:latest
-ENV ARCH=x86
+ENV ARCH=amd64
 RUN apk --no-cache --update add gawk bc socat
 COPY *.sh /
 WORKDIR /

--- a/edge/services/cpu_percent/Makefile
+++ b/edge/services/cpu_percent/Makefile
@@ -1,5 +1,5 @@
-# Transform the machine arch into some standard values: "arm", "arm64", or "x86"
-SYSTEM_ARCH := $(shell uname -m | sed -e 's/aarch64.*/arm64/' -e 's/x86_64.*/x86/' -e 's/armv.*/arm/')
+# Transform the machine arch into some standard values: "arm", "arm64", or "amd64"
+SYSTEM_ARCH := $(shell uname -m | sed -e 's/aarch64.*/arm64/' -e 's/x86_64.*/amd64/' -e 's/armv.*/arm/')
 
 # To build for an arch different from the current system, set this env var to 1 of the values in the comment above
 ARCH ?= $(SYSTEM_ARCH)

--- a/edge/services/cpu_percent/horizon/README.md
+++ b/edge/services/cpu_percent/horizon/README.md
@@ -4,8 +4,7 @@ Fill in the values of the variables in the template with commands like:
 
 ```
 export DOCKER_HUB_ID=openhorizon   # or your own docker hub id
-export ARCH1=x86     # or arm or arm64
-export ARCH2=amd64    # or arm or arm64
+export ARCH2=amd64     # or arm or arm64
 export CPU_VERSION=1.2.2
 
 envsubst < cpu-template.json > cpu.json

--- a/edge/services/cpu_percent/horizon/cpu-template.json
+++ b/edge/services/cpu_percent/horizon/cpu-template.json
@@ -1,5 +1,5 @@
 {
-  "label": "CPU for $ARCH1",
+  "label": "CPU for $ARCH2",
   "description": "Provides a REST API to query the CPU load",
   "public": true,
   "specRef": "https://internetofthings.ibmcloud.com/microservices/cpu",
@@ -11,7 +11,7 @@
   "userInput": [],
   "workloads": [
     {
-      "deployment": "{\"services\":{\"cpu\":{\"image\":\"$DOCKER_HUB_ID/example_ms_${ARCH1}_cpu:$CPU_VERSION\"}}}",
+      "deployment": "{\"services\":{\"cpu\":{\"image\":\"$DOCKER_HUB_ID/example_ms_${ARCH2}_cpu:$CPU_VERSION\"}}}",
       "deployment_signature": "",
       "torrent": "{\"url\":\"\",\"signature\":\"\"}"
     }

--- a/edge/wiotp/cpu2wiotp/Dockerfile.amd64
+++ b/edge/wiotp/cpu2wiotp/Dockerfile.amd64
@@ -1,5 +1,5 @@
 FROM alpine:latest
-ENV ARCH=x86
+ENV ARCH=amd64
 RUN apk --no-cache --update add curl mosquitto-clients
 COPY *.sh /
 COPY *.pem /

--- a/edge/wiotp/cpu2wiotp/Makefile
+++ b/edge/wiotp/cpu2wiotp/Makefile
@@ -1,5 +1,5 @@
-# Transform the machine arch into some standard values: "arm", "arm64", or "x86"
-SYSTEM_ARCH := $(shell uname -m | sed -e 's/aarch64.*/arm64/' -e 's/x86_64.*/x86/' -e 's/armv.*/arm/')
+# Transform the machine arch into some standard values: "arm", "arm64", or "amd64"
+SYSTEM_ARCH := $(shell uname -m | sed -e 's/aarch64.*/arm64/' -e 's/x86_64.*/amd64/' -e 's/armv.*/arm/')
 
 # To build for an arch different from the current system, set this env var to 1 of the values in the comment above
 ARCH ?= $(SYSTEM_ARCH)

--- a/edge/wiotp/cpu2wiotp/horizon/README.md
+++ b/edge/wiotp/cpu2wiotp/horizon/README.md
@@ -4,7 +4,6 @@ Fill in the values of the variables in the template with commands like:
 
 ```
 export DOCKER_HUB_ID=openhorizon   # or your own docker hub id
-export ARCH1=x86     # or arm or arm64
 export ARCH2=amd64    # or arm or arm64
 export CPU2WIOTP_VERSION=1.1.8
 export WIOTP_ORG_ID=abcdef

--- a/edge/wiotp/cpu2wiotp/horizon/cpu2wiotp-template.json
+++ b/edge/wiotp/cpu2wiotp/horizon/cpu2wiotp-template.json
@@ -1,5 +1,5 @@
 {
-  "label": "Cpu2wiotp for $ARCH1",
+  "label": "Cpu2wiotp for $ARCH2",
   "description": "Sample Horizon workload that repeatedly reads the CPU load and sends it to WIoTP",
   "public": true,
   "workloadUrl": "https://internetofthings.ibmcloud.com/workloads/cpu2wiotp",
@@ -47,7 +47,7 @@
   ],
   "workloads": [
     {
-      "deployment": "{\"services\":{\"cpu2wiotp\":{\"image\":\"$DOCKER_HUB_ID/example_wl_${ARCH1}_cpu2wiotp:$CPU2WIOTP_VERSION\",\"binds\":[\"/var/wiotp-edge:/var/wiotp-edge\"],\"environment\":[\"WIOTP_DOMAIN=internetofthings.ibmcloud.com\",\"WIOTP_EDGE_MQTT_IP=localhost\",\"WIOTP_PEM_FILE=/var/wiotp-edge/persist/dc/ca/ca.pem\"]}}}",
+      "deployment": "{\"services\":{\"cpu2wiotp\":{\"image\":\"$DOCKER_HUB_ID/example_wl_${ARCH2}_cpu2wiotp:$CPU2WIOTP_VERSION\",\"binds\":[\"/var/wiotp-edge:/var/wiotp-edge\"],\"environment\":[\"WIOTP_DOMAIN=internetofthings.ibmcloud.com\",\"WIOTP_EDGE_MQTT_IP=localhost\",\"WIOTP_PEM_FILE=/var/wiotp-edge/persist/dc/ca/ca.pem\"]}}}",
       "deployment_signature": "",
       "torrent": "{\"url\":\"\",\"signature\":\"\"}"
     }

--- a/edge/wiotp/cpu2wiotp/horizon/pattern/cpu2wiotp-template.json
+++ b/edge/wiotp/cpu2wiotp/horizon/pattern/cpu2wiotp-template.json
@@ -1,5 +1,5 @@
 {
-  "label": "Cpu2wiotp for x86, arm, and arm64",
+  "label": "Cpu2wiotp for amd64, arm, and arm64",
   "description": "Horizon deployment pattern that runs the cpu2wiotp workload",
   "public": true,
   "workloads": [

--- a/edge/wiotp/cpu2wiotp/horizon/pattern/cpu2wiotp-template.json
+++ b/edge/wiotp/cpu2wiotp/horizon/pattern/cpu2wiotp-template.json
@@ -10,7 +10,7 @@
       "workloadVersions": [
         {
           "version": "$CPU2WIOTP_VERSION",
-          "deployment_overrides": "{\"services\":{\"cpu2wiotp\":{\"environment\":[\"WIOTP_DOMAIN=${WIOTP_TEST_ENV2}internetofthings.ibmcloud.com\",\"WIOTP_EDGE_MQTT_IP=${WIOTP_EDGE_MQTT_IP}\",\"VERBOSE=1\"]}}}",
+          "deployment_overrides": "{\"services\":{\"cpu2wiotp\":{\"environment\":[\"WIOTP_DOMAIN=${WIOTP_TEST_ENV2}internetofthings.ibmcloud.com\",\"WIOTP_EDGE_MQTT_IP=edge-connector\",\"VERBOSE=1\"]}}}",
           "deployment_overrides_signature": "",
           "priority": {},
           "upgradePolicy": {}
@@ -28,7 +28,7 @@
       "workloadVersions": [
         {
           "version": "$CPU2WIOTP_VERSION",
-          "deployment_overrides": "{\"services\":{\"cpu2wiotp\":{\"environment\":[\"WIOTP_DOMAIN=${WIOTP_TEST_ENV2}internetofthings.ibmcloud.com\",\"WIOTP_EDGE_MQTT_IP=${WIOTP_EDGE_MQTT_IP}\",\"VERBOSE=1\"]}}}",
+          "deployment_overrides": "{\"services\":{\"cpu2wiotp\":{\"environment\":[\"WIOTP_DOMAIN=${WIOTP_TEST_ENV2}internetofthings.ibmcloud.com\",\"WIOTP_EDGE_MQTT_IP=edge-connector\",\"VERBOSE=1\"]}}}",
           "deployment_overrides_signature": "",
           "priority": {},
           "upgradePolicy": {}
@@ -46,7 +46,7 @@
       "workloadVersions": [
         {
           "version": "$CPU2WIOTP_VERSION",
-          "deployment_overrides": "{\"services\":{\"cpu2wiotp\":{\"environment\":[\"WIOTP_DOMAIN=${WIOTP_TEST_ENV2}internetofthings.ibmcloud.com\",\"WIOTP_EDGE_MQTT_IP=${WIOTP_EDGE_MQTT_IP}\",\"VERBOSE=1\"]}}}",
+          "deployment_overrides": "{\"services\":{\"cpu2wiotp\":{\"environment\":[\"WIOTP_DOMAIN=${WIOTP_TEST_ENV2}internetofthings.ibmcloud.com\",\"WIOTP_EDGE_MQTT_IP=edge-connector\",\"VERBOSE=1\"]}}}",
           "deployment_overrides_signature": "",
           "priority": {},
           "upgradePolicy": {}


### PR DESCRIPTION
Changed the naming of the docker images from x86 to amd64, so we could have just one arch env var in the quick start guide, and reduce confusion.