### PR TITLE
SDR PoC: sdr2msghub now replaces bad chars in msghub topic

### DIFF
--- a/edge/msghub/sdr2msghub/main.go
+++ b/edge/msghub/sdr2msghub/main.go
@@ -184,6 +184,20 @@ func getEnv(keys ...string) (val string) {
 	return
 }
 
+var replacer = strings.NewReplacer(
+	"@", "_",
+	"#", "_",
+	"%", "_",
+	"(", "_",
+	")", "_",
+	"+", "_",
+	"=", "_",
+	":", "_",
+	",", "_",
+	"<", "_",
+	">", "_",
+)
+
 // the default hostname if not overridden
 var hostname string = "sdr"
 
@@ -201,7 +215,7 @@ func main() {
 		panic(err)
 	}
 	fmt.Println("model loaded")
-	topic := getEnv("MSGHUB_TOPIC")
+	topic := replacer.Replace(getEnv("MSGHUB_TOPIC"))
 	fmt.Printf("using topic %s\n", topic)
 	conn, err := connect(topic)
 	if err != nil {


### PR DESCRIPTION
The strings.NewReplacer syntax is a bit verbose, but it's good enough for now.