### PR TITLE
small changes in whether to use IBM or HZN_ORG_ID in poc metadata

### DIFF
--- a/edge/msghub/cpu2msghub/horizon/pattern/cpu2msghub.json
+++ b/edge/msghub/cpu2msghub/horizon/pattern/cpu2msghub.json
@@ -5,7 +5,7 @@
   "services": [
     {
       "serviceUrl": "https://$MYDOMAIN/service-${CPU2MSGHUB_NAME}",
-      "serviceOrgid": "IBM",
+      "serviceOrgid": "$HZN_ORG_ID",
       "serviceArch": "amd64",
       "serviceVersions": [
         {
@@ -15,7 +15,7 @@
     },
     {
       "serviceUrl": "https://$MYDOMAIN/service-${CPU2MSGHUB_NAME}",
-      "serviceOrgid": "IBM",
+      "serviceOrgid": "$HZN_ORG_ID",
       "serviceArch": "arm",
       "serviceVersions": [
         {
@@ -25,7 +25,7 @@
     },
     {
       "serviceUrl": "https://$MYDOMAIN/service-${CPU2MSGHUB_NAME}",
-      "serviceOrgid": "IBM",
+      "serviceOrgid": "$HZN_ORG_ID",
       "serviceArch": "arm64",
       "serviceVersions": [
         {

--- a/edge/msghub/cpu2msghub/horizon/service.definition.json
+++ b/edge/msghub/cpu2msghub/horizon/service.definition.json
@@ -10,13 +10,13 @@
     "requiredServices": [
         {
             "url": "https://$MYDOMAIN/service-$CPU_NAME",
-            "org": "$HZN_ORG_ID",
+            "org": "IBM",
             "version": "$CPU_VERSION",
             "arch": "$ARCH"
         },
         {
             "url": "https://$MYDOMAIN/service-$GPS_NAME",
-            "org": "$HZN_ORG_ID",
+            "org": "IBM",
             "version": "$GPS_VERSION",
             "arch": "$ARCH"
         }

--- a/edge/msghub/cpu2msghub/horizon/userinput.json
+++ b/edge/msghub/cpu2msghub/horizon/userinput.json
@@ -2,18 +2,6 @@
     "services": [
         {
             "org": "IBM",
-            "url": "https://$MYDOMAIN/service-$CPU_NAME",
-            "versionRange": "[0.0.0,INFINITY)",
-            "variables": {}
-        },
-        {
-            "org": "IBM",
-            "url": "https://$MYDOMAIN/service-$GPS_NAME",
-            "versionRange": "[0.0.0,INFINITY)",
-            "variables": {}
-        },
-        {
-            "org": "IBM",
             "url": "https://$MYDOMAIN/service-$CPU2MSGHUB_NAME",
             "versionRange": "[0.0.0,INFINITY)",
             "variables": {

--- a/edge/msghub/sdr2msghub/horizon/pattern/sdr2msghub.json
+++ b/edge/msghub/sdr2msghub/horizon/pattern/sdr2msghub.json
@@ -5,7 +5,7 @@
   "services": [
     {
       "serviceUrl": "https://$MYDOMAIN/service-${SDR2MSGHUB_NAME}",
-      "serviceOrgid": "IBM",
+      "serviceOrgid": "$HZN_ORG_ID",
       "serviceArch": "amd64",
       "serviceVersions": [
         {
@@ -15,7 +15,7 @@
     },
     {
       "serviceUrl": "https://$MYDOMAIN/service-${SDR2MSGHUB_NAME}",
-      "serviceOrgid": "IBM",
+      "serviceOrgid": "$HZN_ORG_ID",
       "serviceArch": "arm",
       "serviceVersions": [
         {
@@ -25,7 +25,7 @@
     },
     {
       "serviceUrl": "https://$MYDOMAIN/service-${SDR2MSGHUB_NAME}",
-      "serviceOrgid": "IBM",
+      "serviceOrgid": "$HZN_ORG_ID",
       "serviceArch": "arm64",
       "serviceVersions": [
         {

--- a/edge/msghub/sdr2msghub/horizon/service.definition.json
+++ b/edge/msghub/sdr2msghub/horizon/service.definition.json
@@ -10,13 +10,13 @@
     "requiredServices": [
         {
             "url": "https://$MYDOMAIN/service-$SDR_NAME",
-            "org": "$HZN_ORG_ID",
+            "org": "IBM",
             "version": "$SDR_VERSION",
             "arch": "$ARCH"
         },
         {
             "url": "https://$MYDOMAIN/service-$GPS_NAME",
-            "org": "$HZN_ORG_ID",
+            "org": "IBM",
             "version": "$GPS_VERSION",
             "arch": "$ARCH"
         }

--- a/edge/msghub/sdr2msghub/horizon/userinput.json
+++ b/edge/msghub/sdr2msghub/horizon/userinput.json
@@ -7,18 +7,6 @@
             "variables": {
                 "MSGHUB_API_KEY": "$MSGHUB_API_KEY"
             }
-        },
-        {
-            "org": "$HZN_ORG_ID",
-            "url": "https://$MYDOMAIN/service-$SDR_NAME",
-            "versionRange": "[0.0.0,INFINITY)",
-            "variables": {}
-        },
-        {
-            "org": "$HZN_ORG_ID",
-            "url": "https://$MYDOMAIN/service-$GPS_NAME",
-            "versionRange": "[0.0.0,INFINITY)",
-            "variables": {}
         }
     ]
 }


### PR DESCRIPTION
The rationale for these changes was to best handle these use cases:
1) **User:** following adding-your-machine, HZN_ORG_ID=cgiroua@us.ibm.com, they register their node with IBM/cpu2msghub pattern
    1) userinput.json: cpu2msghub org hardcoded to IBM, sdr & gps orgs hardcoded to IBM or sections omitted
    2) cpu2msghub.json (pattern): will be used by ibm edge fabric dev to predefine pattern in IBM org, so doesn't matter which way
    3) service.definition.json: will be used by ibm edge fabric dev to predefine cpu2msghub service in IBM org, so doesn't matter which way
2) **Service Developer:** following dev guide, copy cpu2msghub service def, change service url, create service in cgiroua@us.ibm.com org, copy cpu2msghub pattern to cgiroua@us.ibm.com org and change to reference their service
    1) userinput.json: cpu2msghub org needs to be $HZN_ORG_ID or they need to change it to cgiroua@us.ibm.com, sdr & gps orgs hardcoded to IBM or sections omitted
    2) cpu2msghub.json (pattern): they need to change serviceUrl to reference their new service (by changing MYDOMAIN), if serviceOrgid=$HZN_ORG_ID they don't have to change that value
    3) service.definition.json: if org=$HZN_ORG_ID they don't have to change that, if requiredServices.org=IBM they don't have to change that
3) **IBM Edge Fabric Developer Predefining:** set HZN_ORG_ID=IBM before creating service & pattern (and use make targets)
