### PR TITLE
SDR PoC

### DIFF
--- a/edge/msghub/sdr2msghub/Makefile
+++ b/edge/msghub/sdr2msghub/Makefile
@@ -5,7 +5,7 @@ SYSTEM_ARCH := $(shell uname -m | sed -e 's/aarch64.*/arm64/' -e 's/x86_64.*/amd
 export ARCH ?= $(SYSTEM_ARCH)
 
 # Container image version and workload name
-export SDR2MSGHUB_VERSION = 0.0.3
+export SDR2MSGHUB_VERSION = 0.0.4
 export SDR2MSGHUB_NAME = sdr2msghub
 
 # When creating the service definition, we reference these

--- a/edge/services/sdr/Dockerfile.amd64
+++ b/edge/services/sdr/Dockerfile.amd64
@@ -1,8 +1,15 @@
 FROM alpine:latest as rtl_build
 RUN apk --no-cache add git cmake libusb-dev make gcc g++ alpine-sdk
+COPY never_close.patch /tmp/
+COPY signal_hack.patch /tmp/
+WORKDIR /tmp
 RUN git clone https://github.com/texane/librtlsdr
-RUN cd librtlsdr && git checkout rpc
-RUN cd librtlsdr && mkdir build && cd build && cmake ../ && make && make install
+WORKDIR /tmp/librtlsdr
+RUN git checkout rpc
+RUN patch -p1 </tmp/never_close.patch
+RUN patch -p1 </tmp/signal_hack.patch
+
+RUN mkdir build && cd build && cmake ../ && make && make install
 RUN ls /usr/local/bin/rtl_*
 
 FROM golang:1.10.0-alpine as go_build

--- a/edge/services/sdr/Dockerfile.arm
+++ b/edge/services/sdr/Dockerfile.arm
@@ -1,8 +1,15 @@
 FROM arm32v6/alpine:latest as rtl_build
-RUN apk --no-cache add git cmake libusb-dev make gcc  g++ alpine-sdk
+RUN apk --no-cache add git cmake libusb-dev make gcc g++ alpine-sdk
+COPY never_close.patch /tmp/
+COPY signal_hack.patch /tmp/
+WORKDIR /tmp
 RUN git clone https://github.com/texane/librtlsdr
-RUN cd librtlsdr && git checkout rpc
-RUN cd librtlsdr && mkdir build && cd build && cmake ../ && make && make install
+WORKDIR /tmp/librtlsdr
+RUN git checkout rpc
+RUN patch -p1 </tmp/never_close.patch
+RUN patch -p1 </tmp/signal_hack.patch
+
+RUN mkdir build && cd build && cmake ../ && make && make install
 RUN ls /usr/local/bin/rtl_*
 
 FROM arm32v6/golang:1.10.0-alpine as go_build

--- a/edge/services/sdr/Dockerfile.arm64
+++ b/edge/services/sdr/Dockerfile.arm64
@@ -1,8 +1,15 @@
 FROM arm64v8/alpine:latest as rtl_build
 RUN apk --no-cache add git cmake libusb-dev make gcc g++ alpine-sdk
+COPY never_close.patch /tmp/
+COPY signal_hack.patch /tmp/
+WORKDIR /tmp
 RUN git clone https://github.com/texane/librtlsdr
-RUN cd librtlsdr && git checkout rpc
-RUN cd librtlsdr && mkdir build && cd build && cmake ../ && make && make install
+WORKDIR /tmp/librtlsdr
+RUN git checkout rpc
+RUN patch -p1 </tmp/never_close.patch
+RUN patch -p1 </tmp/signal_hack.patch
+
+RUN mkdir build && cd build && cmake ../ && make && make install
 RUN ls /usr/local/bin/rtl_*
 
 FROM arm64v8/golang:1.10.0-alpine as go_build

--- a/edge/services/sdr/Makefile
+++ b/edge/services/sdr/Makefile
@@ -4,7 +4,7 @@ SYSTEM_ARCH := $(shell uname -m | sed -e 's/aarch64.*/arm64/' -e 's/x86_64.*/amd
 # To build for an arch different from the current system, set this env var to 1 of the values in the comment above
 export ARCH ?= $(SYSTEM_ARCH)
 
-export SDR_VERSION = 0.0.5
+export SDR_VERSION = 0.0.7
 export SDR_NAME = sdr
 
 # These variables can be overridden from the environment

--- a/edge/services/sdr/api.md
+++ b/edge/services/sdr/api.md
@@ -1,0 +1,21 @@
+# SDR service API
+
+Assuming that `sdr` is the host name:
+
+## `/freqs`
+Get a list of the frequencies of strong radio stations.
+
+`curl sdr:5427/freqs`
+
+Example response:
+If the SDR hardware is present it will return a list of string FM stations.
+`{"origin":"sdr_hardware","freqs":[89700000,91100000,91900000,93300000,94500000,95700000,96100000,97700000,99100000,101500000,102300000,103700000,105100000,107900000]}`
+
+If the SDR hardware is not present or can not be used for some reason it will return a single station of frequency 0.
+`{"origin":"fake","freqs":[0]}`
+
+## /audio/<freq>
+Get a 30 second chunk of raw audio.
+`curl sdr:5427/audio/99100000`
+
+`curl sdr:5427/audio/99100000 | aplay -r 16000 -f S16_LE -t raw -c 1`

--- a/edge/services/sdr/horizon/envvars.sh.sample
+++ b/edge/services/sdr/horizon/envvars.sh.sample
@@ -1,9 +1,9 @@
 # Set these values appropriate for your Horizon instance
-export HZN_EXCHANGE_URL="stg-edge-cluster.us-south.containers.appdomain.cloud/v1"
+#export HZN_EXCHANGE_URL="stg-edge-cluster.us-south.containers.appdomain.cloud/v1"
 export HZN_ORG_ID=myorg
 export HZN_EXCHANGE_USER_AUTH=myuser:mypw
 export MYDOMAIN=mydomain.com
 export ARCH=amd64   # arch of your edge node: amd64, or arm for Raspberry Pi, or arm64 for TX2
-export PRIVATE_KEY_FILE=$(HOME)/myprivatekeyfile   # see: hzn key -h 
+export PRIVATE_KEY_FILE=$(HOME)/myprivatekeyfile   # see: hzn key -h
 export PUBLIC_KEY_FILE=$(HOME)/mypublickeyfile
 export DOCKER_HUB_ID=mydockerhubid   # your docker hub username, sign up at https://hub.docker.com/sso/start/?next=https://hub.docker.com/

--- a/edge/services/sdr/horizon/service.definition.json
+++ b/edge/services/sdr/horizon/service.definition.json
@@ -6,7 +6,7 @@
   "url": "https://$MYDOMAIN/service-$SDR_NAME",
   "version": "$SDR_VERSION",
   "arch": "$ARCH",
-  "sharable": "single",
+  "sharable": "exclusive",
   "requiredServices": [],
   "userInput": [],
   "deployment": {

--- a/edge/services/sdr/never_close.patch
+++ b/edge/services/sdr/never_close.patch
@@ -1,0 +1,29 @@
+*** librtlsdr/src/rtl_rpcd.c	Thu Mar 31 02:15:48 2016
+--- librtlsdr.hack/src/rtl_rpcd.c	Thu Mar 31 01:50:56 2016
+***************
+*** 503,508 ****
+--- 503,509 ----
+        if (rpcd->dev != NULL)
+        {
+  	/* already opened */
++ 	PRINTF("hack: already open\n");
+  	err = 0;
+  	goto on_error;
+        }
+***************
+*** 522,531 ****
+--- 523,536 ----
+      {
+        uint32_t did;
+  
++ 	PRINTF("hack: keeping open\n");
++ 
++ /*
+        if (rtlsdr_rpc_msg_pop_uint32(q, &did)) goto on_error;
+        if ((rpcd->dev == NULL) || (rpcd->did != did)) goto on_error;
+        err = rtlsdr_close(rpcd->dev);
+        rpcd->dev = NULL;
++ */
+  
+        break ;
+      }

--- a/edge/services/sdr/rtlsdrclientlib/clientlib.go
+++ b/edge/services/sdr/rtlsdrclientlib/clientlib.go
@@ -66,7 +66,7 @@ type PowerDist struct {
 }
 
 func GetFreqs(hostname string) (freqs Freqs, err error) {
-	timeout := time.Duration(20 * time.Second)
+	timeout := time.Duration(40 * time.Second)
 	client := http.Client{
 		Timeout: timeout,
 	}

--- a/edge/services/sdr/signal_hack.patch
+++ b/edge/services/sdr/signal_hack.patch
@@ -1,0 +1,25 @@
+*** librtlsdr/src/rtl_rpcd.c	Thu Mar 31 15:08:54 2016
+--- librtlsdr.hack/src/rtl_rpcd.c	Thu Mar 31 17:10:16 2016
+***************
+*** 15,20 ****
+--- 15,21 ----
+  #include <netdb.h>
+  #include <rtl-sdr.h>
+  #include "rtlsdr_rpc_msg.h"
++ #include <signal.h>
+  
+  
+  #if 1
+***************
+*** 1105,1110 ****
+--- 1106,1115 ----
+    const char* addr;
+    const char* port;
+  
++ 
++   PRINTF("hack: ignoring sigpipe\n");
++   signal(SIGPIPE, SIG_IGN);
++ 
+    addr = getenv("RTLSDR_RPC_SERV_ADDR");
+    if (addr == NULL) addr = "0.0.0.0";
+  


### PR DESCRIPTION
- Apply patch to rtl_rpcd to make it not close when rtl_fm is killed, and actually use it to get audio. This properly fixes the issue of getting the hardware into bad states.
- Add basic SDR API docs
- increment versions
- set `"sharable": "exclusive",` in the service definition