### PR TITLE
Correcting error in cpu2msghub service definition

### DIFF
--- a/edge/msghub/cpu2msghub/horizon/service.definition.json
+++ b/edge/msghub/cpu2msghub/horizon/service.definition.json
@@ -12,13 +12,13 @@
         {
             "url": "ibm.cpu",
             "org": "IBM",
-            "version": "[0.0.0,INFINITY)",
+            "version": "1.2.5",
             "arch": "$ARCH"
         },
         {
             "url": "ibm.gps",
             "org": "IBM",
-            "version": "[0.0.0,INFINITY)",
+            "version": "2.0.7",
             "arch": "$ARCH"
         }
     ],


### PR DESCRIPTION
Mistakenly changed the version of the dependent services to 0-infinity in the service.definition.json file of cpu2msghub instead of specifying the new version