### PR TITLE
SDR Makefile Update

### DIFF
--- a/edge/services/sdr/Makefile
+++ b/edge/services/sdr/Makefile
@@ -46,6 +46,10 @@ publish-all-arches:
 	ARCH=arm $(MAKE) build-test-publish
 	ARCH=arm64 $(MAKE) build-test-publish
 
+# target for script - overwrite and pull insitead of push docker image
+publish-service-overwrite:
+	hzn exchange service publish -O -P -f horizon/service.definition.json
+
 # new target for icp exchange to run on startup to publish only
 publish-only:
 	ARCH=amd64 $(MAKE) publish-service


### PR DESCRIPTION
Forgot to add new flag for `hzn exchange service publish` to have sdr pull and overwrite if there is an existing version already in the exchange