### PR TITLE
Edge device files script & small README updates

### DIFF
--- a/edge/evtstreams/cpu2evtstreams/CreateService.md
+++ b/edge/evtstreams/cpu2evtstreams/CreateService.md
@@ -139,7 +139,7 @@ sudo docker ps
 
 16. On any machine, subscribe to the Event Streams topic to see the json data that cpu2evtstreams is sending:
 ```
-kafkacat -C -q -o end -f "%t/%p/%o/%k: %s\n" -b $EVTSTREAMS_BROKER_URL -X api.version.request=true -X security.protocol=sasl_ssl -X sasl.mechanisms=PLAIN -X sasl.username=token -X sasl.password=$EVTSTREAMS_API_KEY -X ssl.ca.location=$EVTSTREAMS_CERT_FILE -t $EVTSTREAMS_TOPIC
+kafkacat -C -q -o end -f "%t/%p/%o/%k: %s\n" -b $EVTSTREAMS_BROKER_URL -X api.version.request=true -X security.protocol=sasl_ssl -X sasl.mechanisms=PLAIN -X sasl.username=token -X sasl.password=$EVTSTREAMS_API_KEY -X ssl.ca.location=$EVTSTREAMS_CERT_FILE -t cpu2evtstreams
 ```
 
 17. See the cpu2evtstreams service output:

--- a/edge/evtstreams/cpu2evtstreams/README.md
+++ b/edge/evtstreams/cpu2evtstreams/README.md
@@ -74,7 +74,7 @@ sudo docker ps
 
 5. On any machine, install [kafkacat](https://github.com/edenhill/kafkacat#install), then subscribe to the Event Streams topic to see the json data that cpu2evtstreams is sending:
   ```
-  kafkacat -C -q -o end -f "%t/%p/%o/%k: %s\n" -b $EVTSTREAMS_BROKER_URL -X api.version.request=true -X security.protocol=sasl_ssl -X sasl.mechanisms=PLAIN -X sasl.username=token -X sasl.password=$EVTSTREAMS_API_KEY -X ssl.ca.location=$EVTSTREAMS_CERT_FILE -t $EVTSTREAMS_TOPIC
+  kafkacat -C -q -o end -f "%t/%p/%o/%k: %s\n" -b $EVTSTREAMS_BROKER_URL -X api.version.request=true -X security.protocol=sasl_ssl -X sasl.mechanisms=PLAIN -X sasl.username=token -X sasl.password=$EVTSTREAMS_API_KEY -X ssl.ca.location=$EVTSTREAMS_CERT_FILE -t cpu2evtstreams
   ```
 6. See the cpu2evtstreams service output:
 

--- a/edge/evtstreams/cpu2evtstreams/README.md
+++ b/edge/evtstreams/cpu2evtstreams/README.md
@@ -107,7 +107,33 @@ hzn unregister -f
 
 - As an alternative to specifying a Deployment Pattern when you register your Edge Node, you may register with a Node Policy.
 
-1. Make sure your Edge Node is not registered by running:
+1. Install `git`:
+
+On **Linux**:
+
+```bash
+sudo apt install -y git
+```
+
+On **macOS**:
+
+```bash
+brew install git jq
+```
+
+2. If you have not done so already, clone this git repo:
+
+```bash
+git clone git@github.com:open-horizon/examples.git
+```
+
+3. Go to the `cpu2evtstreams` directory:
+
+```bash
+cd examples/edge/evtstreams/cpu2evtstreams
+```
+
+4. Make sure your Edge Node is not registered by running:
 
 ```
 hzn unregister -f
@@ -128,18 +154,18 @@ hzn unregister -f
 
 - It provides values for three `properties` (`model`, `year`, and `os`). It states no `constraints`, so any appropriately signed and authorized code can be deployed on this Edge Node,
 
-2. Get the user input file for the cpu2evtstreams sample:
+5. Get the user input file for the cpu2evtstreams sample:
 ```
 wget https://github.com/open-horizon/examples/raw/master/edge/evtstreams/cpu2evtstreams/horizon/use/userinput.json
 ```
 
-3. Register your Node Policy using this command:
+6. Register your Node Policy using this command:
 
 ```
 hzn register --policy horizon/node_policy.json -f userinput.json
 ```
 
-4. When the registration completes, use the following command to review the Node Policy:
+7. When the registration completes, use the following command to review the Node Policy:
 
 ```
 hzn policy list
@@ -165,13 +191,17 @@ hzn policy list
 
 - Note this simple Service Policy doesn't provide any `properties`, but it does have a `constraint`. This example `constraint` is one that a Service developer might add, stating that their Service must only run on the models named `Mac` or `Pi3B `. If you recall the Node Policy we used above, the model `property` was set to `Mac`, so this Service should be compatible with our Edge Node.
 
-1. To attach the example Service policy to this service, use the following command (substituting your service name):
+1. List the services in your org:
+```bash
+hzn exchange service list
+```
+2. To attach the example Service policy to this service, use the following command (substituting your service name):
 
 ```
 hzn exchange service addpolicy -f horizon/service_policy.json <published-cpu2evtstreams-service-name>
 ```
 
-2. Once that completes, you can look at the results with the following command:
+3. Once that completes, you can look at the results with the following command:
 
 ```
 hzn exchange service listpolicy <published-cpu2evtstreams-service-name>

--- a/edge/evtstreams/cpu2evtstreams/README.md
+++ b/edge/evtstreams/cpu2evtstreams/README.md
@@ -118,7 +118,7 @@ sudo apt install -y git
 On **macOS**:
 
 ```bash
-brew install git jq
+brew install git
 ```
 
 2. If you have not done so already, clone this git repo:

--- a/edge/services/helloworld/README.md
+++ b/edge/services/helloworld/README.md
@@ -102,7 +102,7 @@ sudo apt install -y git
 On **macOS**:
 
 ```bash
-brew install git jq
+brew install git 
 ```
 
 2. If you have not done so already, clone this git repo:

--- a/edge/services/helloworld/README.md
+++ b/edge/services/helloworld/README.md
@@ -91,7 +91,33 @@ The Horizon Policy mechanism offers an alternative to using Deployment Patterns.
 
 - As an alternative to specifying a Deployment Pattern when you register your Edge Node, you may register with a Node Policy.
 
-1. Make sure your Edge Node is not registered by running:
+1. Install `git`:
+
+On **Linux**:
+
+```bash
+sudo apt install -y git
+```
+
+On **macOS**:
+
+```bash
+brew install git jq
+```
+
+2. If you have not done so already, clone this git repo:
+
+```bash
+git clone git@github.com:open-horizon/examples.git
+```
+
+3. Go to the `helloworld` directory:
+
+```bash
+cd examples/edge/services/helloworld
+```
+
+4. Make sure your Edge Node is not registered by running:
 
 ```bash
 hzn unregister -f
@@ -113,13 +139,13 @@ hzn unregister -f
 
 - It provides values for three `properties` (`model`, `serial`, and `configuration`). It states no `constraints`, so any appropriately signed and authorized code can be deployed on this Edge Node,
 
-2. Register your Node Policy using this command:
+5. Register your Node Policy using this command:
 
 ```bash
 hzn register --policy horizon/node_policy.json
 ```
 
-3. When the registration completes, use the following command to review the Node Policy:
+6. When the registration completes, use the following command to review the Node Policy:
 
 ```bash
 hzn policy list
@@ -145,13 +171,18 @@ hzn policy list
 
 - Note this simple Service Policy doesn't provide any `properties`, but it does have a `constraint`. This example `constraint` is one that a Service developer might add, stating that their Service must only run on the models named `Whatsit ULTRA` or `Thingamajig ULTRA`. If you recall the Node Policy we used above, the model `property` was set to `Thingamajig ULTRA`, so this Service should be compatible with our Edge Node.
 
-1. To attach the example Service policy to this service, use the following command (substituting your service name):
+1. List the services in your org:
+```bash
+hzn exchange service list
+```
+
+2. To attach the example Service policy to this service, use the following command (substituting your service name):
 
 ```bash
 hzn exchange service addpolicy -f horizon/service_policy.json <published-helloworld-service-name>
 ```
 
-2. Once that completes, you can look at the results with the following command:
+3. Once that completes, you can look at the results with the following command:
 
 ```bash
 hzn exchange service listpolicy <published-helloworld-service-name>

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -162,9 +162,9 @@ function checkAPIKey () {
 	KEY=$(cloudctl iam api-keys | cut -d' ' -f4 | grep "$USER-Edge-Device-API-Key")
 	if [ -z $KEY ]; then
 		echo "\"$USER-Edge-Device-API-Key\" does not exist. A new one will be created."
-        echo ""
         CREATE_NEW_KEY=true
     else 
+    	echo "\"$USER-Edge-Device-API-Key\" already exists. Skipping key creation."
     	CREATE_NEW_KEY=false
     fi
     echo ""
@@ -212,7 +212,7 @@ function getClusterCert () {
 	echo "Getting the IBM Cloud Pak self-signed certificate agent-install.crt..."
 	echo "kubectl -n kube-public get secret ibmcloud-cluster-ca-cert -o jsonpath=\"{.data['ca\.crt']}\" | base64 --decode > agent-install.crt"
 
-	kubectl -n kube-public get secret ibmcloud-cluster-ca-cert -o jsonpath="{.data['ca\.crt']}" | base64 --decode > agent-install.crt
+	kubectl --namespace kube-system get secret cluster-ca-cert -o jsonpath="{.data['tls\.crt']}" | base64 --decode > agent-install.crt
 	if [ $? -ne 0 ]; then
 		echo "ERROR: Failed to get the IBM Cloud Pak self-signed certificate"
         echo ""
@@ -224,11 +224,11 @@ function getClusterCert () {
 # Locate the IBM Edge Computing for Devices installation content
 function gatherHorizonFiles () {
 	echo "Locating the IBM Edge Computing Manager for Devices installation content for $EDGE_DEVICE device..."
-	echo "tar --strip-components n -zxvf ibm-edge-computing-x86_64-3.2.1.1.tar.gz ibm-edge-computing-x86_64-3.2.1.1/horizon-edge-packages/..."
+	echo "tar --strip-components n -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/..."
 
     # Determine edge device type, and distribution if applicable 
     if [[ "$EDGE_DEVICE" == "32-bit-ARM" ]]; then
-		tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-3.2.1.1.tar.gz ibm-edge-computing-x86_64-3.2.1.1/horizon-edge-packages/linux/raspbian/stretch/armhf
+		tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/raspbian/stretch/armhf
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
         	echo ""
@@ -237,9 +237,9 @@ function gatherHorizonFiles () {
 
 	elif [[ "$EDGE_DEVICE" == "64-bit-ARM" ]]; then
 		if [[ "$DISTRO" == "xenial" ]]; then
-			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-3.2.1.1.tar.gz ibm-edge-computing-x86_64-3.2.1.1/horizon-edge-packages/linux/ubuntu/xenial/arm64
+			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/ubuntu/xenial/arm64
 		else
-			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-3.2.1.1.tar.gz ibm-edge-computing-x86_64-3.2.1.1/horizon-edge-packages/linux/ubuntu/bionic/arm64
+			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/ubuntu/bionic/arm64
 		fi
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
@@ -249,9 +249,9 @@ function gatherHorizonFiles () {
 
 	elif [[ "$EDGE_DEVICE" == "x86_64-Linux" ]]; then
 		if [[ "$DISTRO" == "xenial" ]]; then
-			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-3.2.1.1.tar.gz ibm-edge-computing-x86_64-3.2.1.1/horizon-edge-packages/linux/ubuntu/xenial/amd64
+			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/ubuntu/xenial/amd64
 		else	
-			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-3.2.1.1.tar.gz ibm-edge-computing-x86_64-3.2.1.1/horizon-edge-packages/linux/ubuntu/bionic/amd64
+			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/ubuntu/bionic/amd64
 		fi
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
@@ -260,7 +260,7 @@ function gatherHorizonFiles () {
     	fi
 
 	elif [[ "$EDGE_DEVICE" == "macOS" ]]; then
-		tar --strip-components 3 -zxvf ibm-edge-computing-x86_64-3.2.1.1.tar.gz ibm-edge-computing-x86_64-3.2.1.1/horizon-edge-packages/macos
+		tar --strip-components 3 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/macos
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
         	echo ""
@@ -327,11 +327,11 @@ function moveFiles () {
 # If an API Key was created, print it out
 function printApiKey () {
 	echo ""
-	echo "******************** Your created API Key **********************"
+	echo "************************** Your created API Key ******************************"
 	echo ""
 	echo "     $USER-Edge-Device-API-Key: $API_KEY"
 	echo ""
-	echo "*************** Save this value for future use *****************"
+	echo "********************* Save this value for future use *************************"
 	echo ""
 }
 

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -306,7 +306,7 @@ function createTarFile () {
 # Move gathered files to specified -f directory 
 function moveFiles () {
 	echo "Moving files to $DIR..."
-	if ! [[ -d "$DIRECTORY" ]]; then
+	if ! [[ -d "$DIR" ]]; then
     	echo "$DIR does not exist, creating it..."
     	mkdir $DIR
 	fi

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -27,7 +27,7 @@ Parameters:
     -f 				<directory> to move gathered files to. Default is current directory
 
 Required Environment Variables:
-    ICP_URL			https://<cluster_CA_domain>:<port-number>
+    CLUSTER_URL			https://<cluster_CA_domain>:<port-number>
     USER 			your-cluster-admin-user
     PW				your-cluster-admin-password
 
@@ -101,9 +101,9 @@ function checkEnvVars () {
 
 	echo "Checking environment variables..."
 
-	if [ -z $ICP_URL ]; then
-		echo "ERROR: ICP_URL environment variable is not set. Can not run 'cloudctl login ...'"
-		echo " - ICP_URL=https://<cluster_CA_domain>:<port-number>"
+	if [ -z $CLUSTER_URL ]; then
+		echo "ERROR: CLUSTER_URL environment variable is not set. Can not run 'cloudctl login ...'"
+		echo " - CLUSTER_URL=https://<cluster_CA_domain>:<port-number>"
 		echo ""
 		exit 1 	
 
@@ -119,7 +119,7 @@ function checkEnvVars () {
 		echo ""
 		exit 1 
 	fi
-	echo " - ICP_URL set"
+	echo " - CLUSTER_URL set"
 	echo " - USER set"
 	echo " - PW set"
 	echo ""
@@ -127,11 +127,11 @@ function checkEnvVars () {
 
 function cloudLogin () {
 	echo "Connecting to cluster and configure kubectl..."
-	echo "cloudctl login -a $ICP_URL -u $USER -p $PW -n kube-public --skip-ssl-validation"
+	echo "cloudctl login -a $CLUSTER_URL -u $USER -p $PW -n kube-public --skip-ssl-validation"
 
-	cloudctl login -a $ICP_URL -u $USER -p $PW -n kube-public --skip-ssl-validation
+	cloudctl login -a $CLUSTER_URL -u $USER -p $PW -n kube-public --skip-ssl-validation
 	if [ $? -ne 0 ]; then
-		echo "ERROR: 'cloudctl login' failed. Check if ICP_URL, USER, and PW environment variables are set correctly."
+		echo "ERROR: 'cloudctl login' failed. Check if CLUSTER_URL, USER, and PW environment variables are set correctly."
         echo ""
         exit 1
     fi
@@ -192,8 +192,8 @@ function createAgentInstallConfig () {
 	echo "Creating agent-install.cfg file..."
 
 	cat << EndOfContent > agent-install.cfg
-HZN_EXCHANGE_URL=$ICP_URL/ec-exchange/v1/
-HZN_FSS_CSSURL=$ICP_URL/ec-css/
+HZN_EXCHANGE_URL=$CLUSTER_URL/ec-exchange/v1/
+HZN_FSS_CSSURL=$CLUSTER_URL/ec-css/
 HZN_ORG_ID=$CLUSTER_NAME
 EndOfContent
 	if [ $? -ne 0 ]; then

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -21,13 +21,13 @@ Parameters:
 				  use this flag with < 64-bit-ARM or x86_64-Linux > 
 				  to specify \`xenial\` build 
 				  Flag is ignored with < macOS >
-    -k 				include this flag to create a new $USER-API-Key. If this flag is not set, 
-				  the existing api keys will be checked for $USER-API-Key and creation will 
+    -k 				include this flag to create a new $USER-Edge-Device-API-Key. If this flag is not set, 
+				  the existing api keys will be checked for $USER-Edge-Device-API-Key and creation will 
 				  be skipped if it exists
     -f 				<directory> to move gathered files to. Default is current directory
 
 Required Environment Variables:
-    CLUSTER_URL			https://<cluster_CA_domain>:<port-number>
+    ICP_URL			https://<cluster_CA_domain>:<port-number>
     USER 			your-cluster-admin-user
     PW				your-cluster-admin-password
 
@@ -101,9 +101,9 @@ function checkEnvVars () {
 
 	echo "Checking environment variables..."
 
-	if [ -z $CLUSTER_URL ]; then
-		echo "ERROR: CLUSTER_URL environment variable is not set. Can not run 'cloudctl login ...'"
-		echo " - CLUSTER_URL=https://<cluster_CA_domain>:<port-number>"
+	if [ -z $ICP_URL ]; then
+		echo "ERROR: ICP_URL environment variable is not set. Can not run 'cloudctl login ...'"
+		echo " - ICP_URL=https://<cluster_CA_domain>:<port-number>"
 		echo ""
 		exit 1 	
 
@@ -119,7 +119,7 @@ function checkEnvVars () {
 		echo ""
 		exit 1 
 	fi
-	echo " - CLUSTER_URL set"
+	echo " - ICP_URL set"
 	echo " - USER set"
 	echo " - PW set"
 	echo ""
@@ -127,11 +127,11 @@ function checkEnvVars () {
 
 function cloudLogin () {
 	echo "Connecting to cluster and configure kubectl..."
-	echo "cloudctl login -a $CLUSTER_URL -u $USER -p $PW -n kube-public --skip-ssl-validation"
+	echo "cloudctl login -a $ICP_URL -u $USER -p $PW -n kube-public --skip-ssl-validation"
 
-	cloudctl login -a $CLUSTER_URL -u $USER -p $PW -n kube-public --skip-ssl-validation
+	cloudctl login -a $ICP_URL -u $USER -p $PW -n kube-public --skip-ssl-validation
 	if [ $? -ne 0 ]; then
-		echo "ERROR: 'cloudctl login' failed. Check if CLUSTER_URL, USER, and PW environment variables are set correctly."
+		echo "ERROR: 'cloudctl login' failed. Check if ICP_URL, USER, and PW environment variables are set correctly."
         echo ""
         exit 1
     fi
@@ -156,12 +156,12 @@ function getClusterName () {
 
 # Check if an IBM Cloud Pak platform API key exists
 function checkAPIKey () {
-	echo "Checking if API key already exists for $USER..."
-	echo "cloudctl iam api-keys | cut -d' ' -f4 | grep \"$USER-API-Key\""
+	echo "Checking if USER-Edge-Device-API-Key already exists..."
+	echo "cloudctl iam api-keys | cut -d' ' -f4 | grep \"$USER-Edge-Device-API-Key\""
 
-	KEY=$(cloudctl iam api-keys | cut -d' ' -f4 | grep "$USER-API-Key")
+	KEY=$(cloudctl iam api-keys | cut -d' ' -f4 | grep "$USER-Edge-Device-API-Key")
 	if [ -z $KEY ]; then
-		echo "\"$USER-API-Key\" does not exist. A new one will be created."
+		echo "\"$USER-Edge-Device-API-Key\" does not exist. A new one will be created."
         echo ""
         CREATE_NEW_KEY=true
     else 
@@ -173,9 +173,9 @@ function checkAPIKey () {
 # Create a IBM Cloud Pak platform API key
 function createAPIKey () {
 	echo "Creating IBM Cloud Pak platform API key..."
-	echo "cloudctl iam api-key-create \"$USER-API-Key\" -d \"$USER API Key\" -f key.txt"
+	echo "cloudctl iam api-key-create \"$USER-Edge-Device-API-Key\" -d \"$USER-Edge-Device-API-Key\" -f key.txt"
 
-	cloudctl iam api-key-create "$USER-API-Key" -d "$USER API Key" -f key.txt
+	cloudctl iam api-key-create "$USER-Edge-Device-API-Key" -d "$USER-Edge-Device-API-Key" -f key.txt
 	if [ $? -ne 0 ]; then
 		echo "ERROR: Failed to create API Key."
         echo ""
@@ -183,7 +183,7 @@ function createAPIKey () {
     fi
 
     API_KEY=$(cat key.txt | jq -r '.apikey')
-    echo " - API Key: $API_KEY"
+    echo " - $USER-Edge-Device-API-Key: $API_KEY"
     echo ""
 }
 
@@ -192,8 +192,8 @@ function createAgentInstallConfig () {
 	echo "Creating agent-install.cfg file..."
 
 	cat << EndOfContent > agent-install.cfg
-HZN_EXCHANGE_URL=$CLUSTER_URL/ec-exchange/v1/
-HZN_FSS_CSSURL=$CLUSTER_URL/ec-css/
+HZN_EXCHANGE_URL=$ICP_URL/ec-exchange/v1/
+HZN_FSS_CSSURL=$ICP_URL/ec-css/
 HZN_ORG_ID=$CLUSTER_NAME
 EndOfContent
 	if [ $? -ne 0 ]; then
@@ -329,7 +329,7 @@ function printApiKey () {
 	echo ""
 	echo "******************** Your created API Key **********************"
 	echo ""
-	echo "        value: $API_KEY"
+	echo "     $USER-Edge-Device-API-Key: $API_KEY"
 	echo ""
 	echo "*************** Save this value for future use *****************"
 	echo ""

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -159,8 +159,8 @@ function checkAPIKey () {
 	echo "Checking if API key already exists for $USER..."
 	echo "cloudctl iam api-keys | cut -d' ' -f4 | grep \"$USER-API-Key\""
 
-	cloudctl iam api-keys | cut -d' ' -f4 | grep "$USER-API-Key"	
-	if [ $? -ne 0 ]; then
+	KEY=$(cloudctl iam api-keys | cut -d' ' -f4 | grep "$USER-API-Key")
+	if [ -z $KEY ]; then
 		echo "\"$USER-API-Key\" does not exist. A new one will be created."
         echo ""
         CREATE_NEW_KEY=true

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -7,7 +7,7 @@ function scriptUsage () {
 	cat << EOF
 ERROR: No arguments specified.
 
-Usage: ./script.sh <edge-device-type> [-t] [-k] [-d <distribution>] [-f <directory>]
+Usage: ./edgeDeviceFiles.sh <edge-device-type> [-t] [-k] [-d <distribution>] [-f <directory>]
 
 Parameters:
   required: 
@@ -345,7 +345,7 @@ main () {
 	checkAPIKey
 
 	if [[ "$CREATE_API_KEY" == "-k" ]] || [[ "$CREATE_NEW_KEY" == "true" ]]; then
-		echo "createAPIKey"
+		createAPIKey
 	fi
 
 	createAgentInstallConfig


### PR DESCRIPTION
edgeDeviceFiles:
- added the `-k` flag to create an API Key even if one is found with `$USER-Api-Key` name 
- changed env var from ICP_URL to CLUSTER_URL 
- added `-f` flag to move files to specified directory. I create it if it does not exist. 
- updated to use 4.0.0 tar file

Samples:
- some small readme updated based on some things I talked about with Parisa when we were walking thru what some uses will do next round of testing