### PR TITLE
update device installation content file name & add support for buster

### DIFF
--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -224,11 +224,11 @@ function getClusterCert () {
 # Locate the IBM Edge Computing for Devices installation content
 function gatherHorizonFiles () {
 	echo "Locating the IBM Edge Computing Manager for Devices installation content for $EDGE_DEVICE device..."
-	echo "tar --strip-components n -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/..."
+	echo "tar --strip-components n -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/..."
 
     # Determine edge device type, and distribution if applicable
     if [[ "$EDGE_DEVICE" == "32-bit-ARM" ]]; then
-		tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/raspbian/stretch/armhf
+		tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/raspbian/stretch/armhf
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
         	echo ""
@@ -237,9 +237,9 @@ function gatherHorizonFiles () {
 
 	elif [[ "$EDGE_DEVICE" == "64-bit-ARM" ]]; then
 		if [[ "$DISTRO" == "xenial" ]]; then
-			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/ubuntu/xenial/arm64
+			tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/ubuntu/xenial/arm64
 		else
-			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/ubuntu/bionic/arm64
+			tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/ubuntu/bionic/arm64
 		fi
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
@@ -249,9 +249,9 @@ function gatherHorizonFiles () {
 
 	elif [[ "$EDGE_DEVICE" == "x86_64-Linux" ]]; then
 		if [[ "$DISTRO" == "xenial" ]]; then
-			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/ubuntu/xenial/amd64
+			tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/ubuntu/xenial/amd64
 		else
-			tar --strip-components 6 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/linux/ubuntu/bionic/amd64
+			tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/ubuntu/bionic/amd64
 		fi
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
@@ -260,7 +260,7 @@ function gatherHorizonFiles () {
     	fi
 
 	elif [[ "$EDGE_DEVICE" == "macOS" ]]; then
-		tar --strip-components 3 -zxvf ibm-edge-computing-x86_64-4.0.0.tar.gz ibm-edge-computing-x86_64-4.0.0/horizon-edge-packages/macos
+		tar --strip-components 3 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/macos
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
         	echo ""

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -228,7 +228,11 @@ function gatherHorizonFiles () {
 
     # Determine edge device type, and distribution if applicable
     if [[ "$EDGE_DEVICE" == "32-bit-ARM" ]]; then
-		tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/raspbian/stretch/armhf
+			if [[ "$DISTR" == "stretch" ]]; then
+				tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/raspbian/stretch/armhf
+			else
+				tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/raspbian/buster/armhf
+			fi
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to locate the IBM Edge Computing Manager for Devices installation content"
         	echo ""

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -43,9 +43,9 @@ while (( "$#" )); do
   	case "$1" in
     	-d) # distribution specified
       		if ! ([[ "$2" == "xenial" ]] \
-						|| [[ "$2" == "bionic" ]] \
-						|| [[ "$2" == "stretch" ]] \
-						|| [[ "$2" == "buster" ]]); then
+					|| [[ "$2" == "bionic" ]] \
+					|| [[ "$2" == "stretch" ]] \
+					|| [[ "$2" == "buster" ]]); then
       			echo "ERROR: Unknown linux distribution type."
       			echo ""
       			exit 1

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -42,7 +42,7 @@ echo "Checking script parameters..."
 while (( "$#" )); do
   	case "$1" in
     	-d) # distribution specified
-      		if ! ([[ "$2" == "xenial" ]] || [[ "$2" == "bionic" ]]); then
+      		if ! ([[ "$2" == "xenial" ]] || [[ "$2" == "bionic" ]] || [[ "$2" == "stretch"]] || [[ "$2" == "buster"]]); then
       			echo "ERROR: Unknown linux distribution type."
       			echo ""
       			exit 1

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -42,7 +42,10 @@ echo "Checking script parameters..."
 while (( "$#" )); do
   	case "$1" in
     	-d) # distribution specified
-      		if ! ([[ "$2" == "xenial" ]] || [[ "$2" == "bionic" ]] || [[ "$2" == "stretch"]] || [[ "$2" == "buster"]]); then
+      		if ! ([[ "$2" == "xenial" ]] \
+						|| [[ "$2" == "bionic" ]] \
+						|| [[ "$2" == "stretch" ]] \
+						|| [[ "$2" == "buster" ]]); then
       			echo "ERROR: Unknown linux distribution type."
       			echo ""
       			exit 1
@@ -225,6 +228,7 @@ function getClusterCert () {
 function gatherHorizonFiles () {
 	echo "Locating the IBM Edge Computing Manager for Devices installation content for $EDGE_DEVICE device..."
 	echo "tar --strip-components n -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/..."
+	echo "Dist is $DISTR"
 
     # Determine edge device type, and distribution if applicable
     if [[ "$EDGE_DEVICE" == "32-bit-ARM" ]]; then

--- a/tools/edgeDeviceFiles.sh
+++ b/tools/edgeDeviceFiles.sh
@@ -228,11 +228,11 @@ function getClusterCert () {
 function gatherHorizonFiles () {
 	echo "Locating the IBM Edge Computing Manager for Devices installation content for $EDGE_DEVICE device..."
 	echo "tar --strip-components n -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/..."
-	echo "Dist is $DISTR"
+	echo "Dist is $DISTRO"
 
     # Determine edge device type, and distribution if applicable
     if [[ "$EDGE_DEVICE" == "32-bit-ARM" ]]; then
-			if [[ "$DISTR" == "stretch" ]]; then
+			if [[ "$DISTRO" == "stretch" ]]; then
 				tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/raspbian/stretch/armhf
 			else
 				tar --strip-components 6 -zxvf ibm-ecm-4.0.0-x86_64.tar.gz ibm-ecm-4.0.0-x86_64/horizon-edge-packages/linux/raspbian/buster/armhf


### PR DESCRIPTION
We've changed the PPA package name.
Also added the ability to use `-d stretch` for the older raspbian stretch image. It now defaults to `buster`