### PR TITLE
fix path of blessedSamples in exchangePublishScript

### DIFF
--- a/tools/exchangePublishScript.sh
+++ b/tools/exchangePublishScript.sh
@@ -11,7 +11,7 @@ branch="-b master"
 repository="https://github.com/open-horizon/examples.git"
 
 # text file containing servies and patterns to publish
-input="$(dirname $0)/examples/tools/blessedSamples.txt"
+input="examples/tools/blessedSamples.txt"
 
 topDir=$(pwd)
 error=0


### PR DESCRIPTION
1-line fix to `exchangePublishScript.sh`: the path for `examples/tools/blessedSamples.txt` should not have `$(dirname $0)` at the beginning, because the examples repo is cloned in the current directory.

This only came up because i was running exchangePublishScript.sh in my local exchange environment, so i don't think you need to put this fix in the `v4.0` branch, just `master`. But please do verify that it still works when run for a real cluster.