### PR TITLE
Quick fix for operator pattern public = true 

### DIFF
--- a/edge/services/helloMMS/README.md
+++ b/edge/services/helloMMS/README.md
@@ -100,7 +100,7 @@ If you haven't done so already, you must do these steps before proceeding with t
   hzn mms object delete -t $HZN_DEVICE_ID.hello-mms --id config.json
   ```
 
-  **Note:** in the service output in the other terminal that this will cause the service to revert to the original config file, and therefore the original "hello" message.
+  Note: in the service output in the other terminal that this will cause the service to revert to the original config file, and therefore the original "hello" message.
 
 8. Unregister your edge node (which will also stop the hello-mms service):
 

--- a/edge/services/operator/simple-operator/deploy/horizon/pattern.json
+++ b/edge/services/operator/simple-operator/deploy/horizon/pattern.json
@@ -2,7 +2,7 @@
     "name": "pattern-${SERVICE_NAME}-$ARCH",
     "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
     "description": "Pattern for $SERVICE_NAME for $ARCH",
-    "public": false,
+    "public": true,
     "services": [
         {
             "serviceUrl": "$SERVICE_NAME",


### PR DESCRIPTION
Before I implement the method of adding the two fields to the `hzn.json` file Lily mentioned she couldn't see the `operator` pattern and I realized it's `public: false` currently 