### PR TITLE
Readd command to get user input file in cpu2evtstreams

### DIFF
--- a/edge/evtstreams/cpu2evtstreams/README.md
+++ b/edge/evtstreams/cpu2evtstreams/README.md
@@ -59,6 +59,7 @@ hzn unregister -f
 
 1. Get the user input file for the cpu2evtstreams sample:
 ```bash
+wget https://raw.githubusercontent.com/open-horizon/examples/master/edge/evtstreams/cpu2evtstreams/horizon/use/userinput.json
 ```
 2. Register your edge node with Horizon to use the cpu2evtstreams pattern:
 ```bash


### PR DESCRIPTION
[1cec1c3](https://github.com/open-horizon/examples/commit/1cec1c3c2e55674a982a87da25ab326fc0d45cec) removed unnecessary commands in the Readme, but additionally removed the command to the get the user input file, which is still necessary. 

Signed-off-by: Clement Ng <clementdng@gmail.com>