### PR TITLE
Change lower level services to run as nonroot

### DIFF
--- a/edge/evtstreams/cpu2evtstreams/service.sh
+++ b/edge/evtstreams/cpu2evtstreams/service.sh
@@ -31,8 +31,8 @@ SAMPLE_SIZE="${SAMPLE_SIZE:-10}"    # the number of cpu samples to read before c
 PUBLISH="${PUBLISH:-true}"    # whether or not to actually send data to IBM Event Streams
 MOCK="${MOCK:-false}"     # if "true", just pretend to call the cpu service REST API
 VERBOSE="${VERBOSE:-0}"    # set to 1 for verbose output
-CPU_URL="${CPU_URL:-http://ibm.cpu:80/v1/ibm.cpu}"
-GPS_URL="${GPS_URL:-http://ibm.gps:80/v1/gps/location}"
+CPU_URL="${CPU_URL:-http://ibm.cpu:8080/v1/ibm.cpu}"
+GPS_URL="${GPS_URL:-http://ibm.gps:8080/v1/gps/location}"
 
 echo "Optional environment variables (or default values): SAMPLE_INTERVAL=$SAMPLE_INTERVAL, SAMPLE_SIZE=$SAMPLE_SIZE, PUBLISH=$PUBLISH, MOCK=$MOCK"
 

--- a/edge/evtstreams/sdr2evtstreams/main.go
+++ b/edge/evtstreams/sdr2evtstreams/main.go
@@ -207,7 +207,7 @@ type locationData struct {
 }
 
 func getGPS() (location locationData, err error) {
-	resp, err := http.Get("http://" + gpshostname + ":80/v1/gps/location")
+	resp, err := http.Get("http://" + gpshostname + ":8080/v1/gps/location")
 	if err != nil {
 		panic(err)
 	}

--- a/edge/services/cpu_percent/Dockerfile.amd64
+++ b/edge/services/cpu_percent/Dockerfile.amd64
@@ -2,4 +2,7 @@ FROM alpine:latest
 RUN apk --no-cache --update add gawk bc socat curl
 COPY *.sh /
 WORKDIR /
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+USER hznuser
+EXPOSE 8080
 CMD /start.sh

--- a/edge/services/cpu_percent/Dockerfile.arm
+++ b/edge/services/cpu_percent/Dockerfile.arm
@@ -2,4 +2,7 @@ FROM arm32v6/alpine:latest
 RUN apk --no-cache --update add gawk bc socat curl 
 COPY *.sh /
 WORKDIR /
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+USER hznuser
+EXPOSE 8080
 CMD /start.sh

--- a/edge/services/cpu_percent/Dockerfile.arm64
+++ b/edge/services/cpu_percent/Dockerfile.arm64
@@ -2,4 +2,7 @@ FROM aarch64/alpine:latest
 RUN apk --no-cache --update add gawk bc socat curl 
 COPY *.sh /
 WORKDIR /
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+USER hznuser
+EXPOSE 8080
 CMD /start.sh

--- a/edge/services/cpu_percent/README.md
+++ b/edge/services/cpu_percent/README.md
@@ -10,7 +10,7 @@ This service takes no input values.
 
 Other Horizon services can use the CPU Percent service by requiring it in its own service definition, and then in its code accessing the CPU Percent REST APIs with the URL:
 ```
-http://ibm.cpu:80/v1/<api-from-the-list-below>
+http://ibm.cpu:8080/v1/<api-from-the-list-below>
 ```
 
 ### **API:** GET /cpu
@@ -35,7 +35,7 @@ body:
 
 #### Example:
 ```
-curl -sS -w "%{http_code}" http://ibm.cpu:80/v1/cpu | jq .
+curl -sS -w "%{http_code}" http://ibm.cpu:8080/v1/cpu
 {
   "cpu": 5.05
 }

--- a/edge/services/cpu_percent/horizon/hzn.json
+++ b/edge/services/cpu_percent/horizon/hzn.json
@@ -3,6 +3,6 @@
     "MetadataVars": {
         "DOCKER_IMAGE_BASE": "openhorizon/ibm.cpu",
         "SERVICE_NAME": "ibm.cpu",
-        "SERVICE_VERSION": "1.2.5"
+        "SERVICE_VERSION": "1.2.6"
     }
 }

--- a/edge/services/cpu_percent/start.sh
+++ b/edge/services/cpu_percent/start.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-socat TCP4-LISTEN:80,fork EXEC:./service.sh
+socat TCP4-LISTEN:8080,fork EXEC:./service.sh
 

--- a/edge/services/gps/Dockerfile.amd64
+++ b/edge/services/gps/Dockerfile.amd64
@@ -44,8 +44,14 @@ RUN apk update && apk add gpsd curl --no-cache ca-certificates
 # Copy in the server binary from stage 0 of the build (above)
 COPY --from=0 /build/bin/amd64_gps /gps
 
+# Create hzngroup and hznuser
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+
+# Run container as hznuser user
+USER hznuser
+
 # The gps service uses this port to respond to REST requests
-EXPOSE 80
+EXPOSE 8080
 
 # Set the default command to be the go executable to start everything
 CMD /gps

--- a/edge/services/gps/Dockerfile.arm
+++ b/edge/services/gps/Dockerfile.arm
@@ -40,8 +40,14 @@ RUN apk update && apk add gpsd curl --no-cache ca-certificates
 # Copy in the server binary from stage 0 of the build (above)
 COPY --from=0 /build/bin/armv6_gps /gps
 
+# Create hzngroup and hznuser
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+
+# Run container as hznuser user
+USER hznuser
+
 # The gps service uses this port to respond to REST requests
-EXPOSE 80
+EXPOSE 8080
 
 # Set the default command to be the go executable to start everything
 CMD /gps

--- a/edge/services/gps/Dockerfile.arm64
+++ b/edge/services/gps/Dockerfile.arm64
@@ -40,8 +40,14 @@ RUN apk update && apk add gpsd curl --no-cache ca-certificates
 # Copy in the server binary from stage 0 of the build (above)
 COPY --from=0 /build/bin/arm64_gps /gps
 
+# Create hzngroup and hznuser
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+
+# Run container as hznuser user
+USER hznuser
+
 # The gps service uses this port to respond to REST requests
-EXPOSE 80
+EXPOSE 8080
 
 # Set the default command to be the go executable to start everything
 CMD /gps

--- a/edge/services/gps/README.md
+++ b/edge/services/gps/README.md
@@ -10,7 +10,7 @@ This service takes no input values. By default, this service will try to use gps
 
 Other Horizon services can use the GPS service by requiring it in its own service definition, and then in its code accessing the GPS REST APIs with the URL:
 ```
-http://ibm.gps:80/v1/<api-from-the-list-below>
+http://ibm.gps:8080/v1/<api-from-the-list-below>
 ```
 
 ### **API:** GET /gps/location
@@ -40,7 +40,7 @@ body:
 
 #### Example:
 ```
-curl -sS -w "%{http_code}" http://ibm.gps:80/v1/gps/location | jq .
+curl -sS -w "%{http_code}" http://ibm.gps:8080/v1/gps/location
 {
   "latitude": 42.052577333,
   "longitude": -73.960314,
@@ -79,7 +79,7 @@ body:
 
 #### Example:
 ```
-curl -sS -w "%{http_code}" http://ibm.gps:80/v1/gps/satellites | jq .
+curl -sS -w "%{http_code}" http://ibm.gps:8080/v1/gps/satellites
 {
   "satellites": [
     {

--- a/edge/services/gps/horizon/hzn.json
+++ b/edge/services/gps/horizon/hzn.json
@@ -3,6 +3,6 @@
     "MetadataVars": {
         "DOCKER_IMAGE_BASE": "openhorizon/ibm.gps",
         "SERVICE_NAME": "ibm.gps",
-        "SERVICE_VERSION": "2.1.2"
+        "SERVICE_VERSION": "2.1.3"
     }
 }

--- a/edge/services/gps/horizon/service.definition.json
+++ b/edge/services/gps/horizon/service.definition.json
@@ -14,7 +14,7 @@
       "name": "HZN_GPS_PORT",
       "label": "REST API port",
       "type": "int",
-      "defaultValue": "80"
+      "defaultValue": "8080"
     },
     {
       "name": "HZN_USE_GPS",

--- a/edge/services/gps/src/main.go
+++ b/edge/services/gps/src/main.go
@@ -176,7 +176,7 @@ const (
 
 // Configuration variable default values
 const (
-	DEFAULT_GPS_PORT             = 80
+	DEFAULT_GPS_PORT             = 8080
 	DEFAULT_USE_GPS              = false
 	DEFAULT_LATITUDE             = 0.0
 	DEFAULT_LONGITUDE            = 0.0

--- a/edge/services/sdr/Dockerfile.amd64
+++ b/edge/services/sdr/Dockerfile.amd64
@@ -30,4 +30,7 @@ COPY --from=rtl_build /usr/local/bin/rtl_fm /bin/rtl_fm
 COPY --from=rtl_build /usr/local/bin/rtl_power /bin/rtl_power
 COPY --from=rtl_build /usr/local/lib/librtlsdr.so.0 /usr/local/lib/librtlsdr.so.0
 WORKDIR /
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+USER hznuser
+EXPOSE 8080
 CMD ["/bin/rtlsdrd"]

--- a/edge/services/sdr/Dockerfile.arm
+++ b/edge/services/sdr/Dockerfile.arm
@@ -30,4 +30,7 @@ COPY --from=rtl_build /usr/local/bin/rtl_fm /bin/rtl_fm
 COPY --from=rtl_build /usr/local/bin/rtl_power /bin/rtl_power
 COPY --from=rtl_build /usr/local/lib/librtlsdr.so.0 /usr/local/lib/librtlsdr.so.0
 WORKDIR /
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+USER hznuser
+EXPOSE 8080
 CMD ["/bin/rtlsdrd"]

--- a/edge/services/sdr/Dockerfile.arm64
+++ b/edge/services/sdr/Dockerfile.arm64
@@ -30,4 +30,7 @@ COPY --from=rtl_build /usr/local/bin/rtl_fm /bin/rtl_fm
 COPY --from=rtl_build /usr/local/bin/rtl_power /bin/rtl_power
 COPY --from=rtl_build /usr/local/lib/librtlsdr.so.0 /usr/local/lib/librtlsdr.so.0
 WORKDIR /
+RUN addgroup -S hzngroup && adduser -S hznuser -G hzngroup
+USER hznuser
+EXPOSE 8080
 CMD ["/bin/rtlsdrd"]

--- a/edge/services/sdr/README.md
+++ b/edge/services/sdr/README.md
@@ -5,7 +5,7 @@ Assuming that `ibm.sdr` is the host name:
 ## `/freqs`
 Get a list of the frequencies of strong radio stations.
 
-`curl ibm.sdr:80/freqs`
+`curl ibm.sdr:8080/freqs`
 
 Example response:
 If the SDR hardware is present it will return a list of string FM stations.
@@ -16,6 +16,6 @@ If the SDR hardware is not present or can not be used for some reason it will re
 
 ## /audio/<freq>
 Get a 30 second chunk of raw audio.
-`curl ibm.sdr:80/audio/99100000`
+`curl ibm.sdr:8080/audio/99100000`
 
-`curl ibm.sdr:80/audio/99100000 | aplay -r 16000 -f S16_LE -t raw -c 1`
+`curl ibm.sdr:8080/audio/99100000 | aplay -r 16000 -f S16_LE -t raw -c 1`

--- a/edge/services/sdr/bbcfake/bbcfake.go
+++ b/edge/services/sdr/bbcfake/bbcfake.go
@@ -88,7 +88,7 @@ func ListLinks() (links map[string]bool, err error) {
 		fmt.Println(err)
 		return
 	}
-	r, err := regexp.Compile("http://www.bbc.co.uk/programmes/([a-z]|[0-9]){8}")
+	r, err := regexp.Compile("https://www.bbc.co.uk/programmes/([a-z]|[0-9]){8}")
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/edge/services/sdr/horizon/hzn.json
+++ b/edge/services/sdr/horizon/hzn.json
@@ -3,6 +3,6 @@
     "MetadataVars": {
         "DOCKER_IMAGE_BASE": "openhorizon/ibm.sdr",
         "SERVICE_NAME": "ibm.sdr",
-        "SERVICE_VERSION": "1.0.1"
+        "SERVICE_VERSION": "1.0.2"
     }
 }

--- a/edge/services/sdr/main.go
+++ b/edge/services/sdr/main.go
@@ -221,5 +221,5 @@ func main() {
 	http.HandleFunc("/audio/", makeAudioHandler(&fake))
 	http.HandleFunc("/power", powerHandler)
 	http.HandleFunc("/freqs", freqsHandler)
-	log.Fatal(http.ListenAndServe(":80", nil))
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/edge/services/sdr/rtlsdrclientlib/clientlib.go
+++ b/edge/services/sdr/rtlsdrclientlib/clientlib.go
@@ -12,7 +12,7 @@ import (
 
 // GetAudio fetches a 30 second chunk of raw audio.
 func GetAudio(hostname string, freq int) (audio []byte, err error) {
-	resp, err := http.Get("http://" + hostname + ":80/audio/" + strconv.Itoa(freq))
+	resp, err := http.Get("http://" + hostname + ":8080/audio/" + strconv.Itoa(freq))
 	if err != nil {
 		panic(err)
 	}
@@ -70,7 +70,7 @@ func GetFreqs(hostname string) (freqs Freqs, err error) {
 	client := http.Client{
 		Timeout: timeout,
 	}
-	resp, err := client.Get("http://" + hostname + ":80/freqs")
+	resp, err := client.Get("http://" + hostname + ":8080/freqs")
 	if err != nil {
 		panic(err)
 	}
@@ -89,7 +89,7 @@ func GetFreqs(hostname string) (freqs Freqs, err error) {
 }
 
 func getPower(hostname string) (power PowerDist, err error) {
-	resp, err := http.Get("http://" + hostname + ":80/power")
+	resp, err := http.Get("http://" + hostname + ":8080/power")
 	if err != nil {
 		panic(err)
 	}

--- a/tools/curlServiceTest.sh
+++ b/tools/curlServiceTest.sh
@@ -15,7 +15,7 @@ api="$(cut -d'.' -f2 <<<"$1")"
 ####################### Loop until until either MATCH is found or TIMEOUT is exceeded #####################
 while true; do
     # exec into container and curl service
-    line=`docker exec -it $contID curl http://$name:80/v1/$api`
+    line=`docker exec -it $contID curl http://$name:8080/v1/$api`
 
     # MATCH was found
     if grep -q -m 1 "$match" <<< "$line"; then


### PR DESCRIPTION
Closes #349

This commit changes the `gps`, `cpu_percent`, and `sdr` examples to run as nonroot, following the example of `helloworld` sample service.

Tested by making sure that updated services continued to function as normal, as well as the services that use these lower level services, such as `sdr2evtstreams` and `cpu2evtstreams`.

Note: there was also a bug that caused the `sdr` service to not return audio, because the link in the regex didn’t match up with the link we were using to get the audio. To properly test `sdr`, I've included that small fix in the `bbcfake.go` file. We also removed instances of `jq .` in the readmes for `cpu_percent` and `gps`, because `jq` is no longer included in those containers. Thanks @t-fine for finding both bugs!

Signed-off-by: Clement Ng <clementdng@gmail.com>