### PR TITLE
Make services "public":false by default for multi-tenancy

### DIFF
--- a/edge/evtstreams/cpu2evtstreams/horizon/pattern-all-arches.json
+++ b/edge/evtstreams/cpu2evtstreams/horizon/pattern-all-arches.json
@@ -2,7 +2,7 @@
   "name": "pattern-$SERVICE_NAME",
   "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
   "description": "Pattern for $SERVICE_NAME sending cpu and gps info to the IBM Event Streams",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/evtstreams/cpu2evtstreams/horizon/pattern.json
+++ b/edge/evtstreams/cpu2evtstreams/horizon/pattern.json
@@ -2,7 +2,7 @@
   "name": "pattern-${SERVICE_NAME}-$ARCH",
   "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
   "description": "Pattern for $SERVICE_NAME sending cpu and gps info to the IBM Event Streams for $ARCH",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/evtstreams/cpu2evtstreams/horizon/service.definition.json
+++ b/edge/evtstreams/cpu2evtstreams/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Sample Horizon service that repeatedly reads the CPU load and GPS location, and sends it to IBM Event Streams",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/evtstreams/cpu2evtstreams/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/evtstreams/sdr2evtstreams/horizon/pattern-all-arches.json
+++ b/edge/evtstreams/sdr2evtstreams/horizon/pattern-all-arches.json
@@ -2,7 +2,7 @@
   "name": "pattern-$SERVICE_NAME",
   "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
   "description": "Pattern for $SERVICE_NAME that sends 30 second clips of FM radio rich in speech to IBM Event Streams",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/evtstreams/sdr2evtstreams/horizon/pattern.json
+++ b/edge/evtstreams/sdr2evtstreams/horizon/pattern.json
@@ -2,7 +2,7 @@
   "name": "pattern-${SERVICE_NAME}-$ARCH",
   "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
   "description": "Pattern for $SERVICE_NAME that sends 30 second clips of FM radio rich in speech to IBM Event Streams for $ARCH",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/evtstreams/sdr2evtstreams/horizon/service.definition.json
+++ b/edge/evtstreams/sdr2evtstreams/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Sample Horizon service that sends 30 second clips of FM radio rich in speech to IBM Event Streams",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/evtstreams/sdr2evtstreams/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/evtstreams/watson_speech2text/horizon/pattern.json
+++ b/edge/evtstreams/watson_speech2text/horizon/pattern.json
@@ -2,7 +2,7 @@
   "name": "pattern-${SERVICE_NAME}-$ARCH",
   "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
   "description": "Pattern for $SERVICE_NAME",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/evtstreams/watson_speech2text/horizon/service.definition.json
+++ b/edge/evtstreams/watson_speech2text/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "zhangl - A super-simple sample Horizon service",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/msghub/watson_speech2text/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/audio2text/horizon/service.definition.json
+++ b/edge/services/audio2text/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME",
     "description": "Audio to Text service",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/audio2text/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/cpu_percent/horizon/service.definition.json
+++ b/edge/services/cpu_percent/horizon/service.definition.json
@@ -2,7 +2,7 @@
   "org": "$HZN_ORG_ID",
   "label": "$SERVICE_NAME for $ARCH",
   "description": "Provides a REST API to query the CPU percent",
-  "public": true,
+  "public": false,
   "documentation": "https://github.com/open-horizon/examples/tree/master/edge/services/cpu_percent/README.md",
   "url": "$SERVICE_NAME",
   "version": "$SERVICE_VERSION",

--- a/edge/services/gps/horizon/service.definition.json
+++ b/edge/services/gps/horizon/service.definition.json
@@ -2,7 +2,7 @@
   "org": "$HZN_ORG_ID",
   "label": "$SERVICE_NAME for $ARCH",
   "description": "Provides the edge node location via a REST API from a GPS sensor, environment variables, or the IP address",
-  "public": true,
+  "public": false,
   "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/gps/README.md",
   "url": "$SERVICE_NAME",
   "version": "$SERVICE_VERSION",

--- a/edge/services/hello-operator/horizon/pattern.json
+++ b/edge/services/hello-operator/horizon/pattern.json
@@ -2,7 +2,7 @@
     "name": "pattern-${SERVICE_NAME}-$ARCH",
     "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
     "description": "Pattern for $SERVICE_NAME for $ARCH",
-    "public": true,
+    "public": false,
     "services": [
         {
             "serviceUrl": "$SERVICE_NAME",

--- a/edge/services/hello-operator/horizon/service.definition.json
+++ b/edge/services/hello-operator/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "",
-    "public": true,
+    "public": false,
     "documentation": "",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/helloMMS/horizon/pattern-all-arches.json
+++ b/edge/services/helloMMS/horizon/pattern-all-arches.json
@@ -2,7 +2,7 @@
   "name": "pattern-$SERVICE_NAME",
   "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
   "description": "Pattern for $SERVICE_NAME",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/services/helloMMS/horizon/pattern.json
+++ b/edge/services/helloMMS/horizon/pattern.json
@@ -2,7 +2,7 @@
   "name": "pattern-${SERVICE_NAME}-$ARCH",
   "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
   "description": "Pattern for $SERVICE_NAME for $ARCH",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/services/helloMMS/horizon/service.definition.json
+++ b/edge/services/helloMMS/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "A super-simple sample Horizon service",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/helloworld/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/helloworld/horizon/pattern-all-arches.json
+++ b/edge/services/helloworld/horizon/pattern-all-arches.json
@@ -2,7 +2,7 @@
   "name": "pattern-$SERVICE_NAME",
   "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
   "description": "Pattern for $SERVICE_NAME",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/services/helloworld/horizon/pattern.json
+++ b/edge/services/helloworld/horizon/pattern.json
@@ -2,7 +2,7 @@
   "name": "pattern-${SERVICE_NAME}-$ARCH",
   "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
   "description": "Pattern for $SERVICE_NAME for $ARCH",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/services/helloworld/horizon/service.definition.json
+++ b/edge/services/helloworld/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "A super-simple sample Horizon service",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/helloworld/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/hotword_detection/horizon/pattern.json
+++ b/edge/services/hotword_detection/horizon/pattern.json
@@ -2,7 +2,7 @@
   "name": "pattern-${SERVICE_NAME}-$ARCH",
   "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
   "description": "Pattern for $SERVICE_NAME",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/services/hotword_detection/horizon/service.definition.json
+++ b/edge/services/hotword_detection/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "zhangl - A super-simple sample Horizon service",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/hotword_detection/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/mqtt2kafka/horizon/service.definition.json
+++ b/edge/services/mqtt2kafka/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Sample Horizon service that receives data via MQTT broker and sends it to IBM Event Streams",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/mqtt2kafka/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/mqtt_broker/horizon/service.definition.json
+++ b/edge/services/mqtt_broker/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "An mqtt broker and publisher for inter-container commmunication",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/mqtt_broker/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/pi3_streamer/horizon/microservice.definition.json
+++ b/edge/services/pi3_streamer/horizon/microservice.definition.json
@@ -2,7 +2,7 @@
   "org": "$HZN_ORG_ID",
   "label": "$PI3STREAMER_NAME for $ARCH",
   "description": "Provides a stream endpoint on LAN from a RPi3 camera feed (RPi Cam)",
-  "public": true,
+  "public": false,
   "specRef": "https://$MYDOMAIN/microservices/$PI3STREAMER_NAME",
   "version": "$PI3STREAMER_VERSION",
   "arch": "$ARCH",

--- a/edge/services/processtext/horizon/pattern.json
+++ b/edge/services/processtext/horizon/pattern.json
@@ -2,7 +2,7 @@
   "name": "pattern-${SERVICE_NAME}-$ARCH",
   "label": "Edge $SERVICE_NAME Service Pattern for $ARCH",
   "description": "Pattern for $SERVICE_NAME, the Offline Voice Assistant",
-  "public": true,
+  "public": false,
   "services": [
     {
       "serviceUrl": "$SERVICE_NAME",

--- a/edge/services/processtext/horizon/service.definition.json
+++ b/edge/services/processtext/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME",
     "description": "Sample Horizon service that acts as an Offline Voice Assistant",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/processtext/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/sdr/horizon/service.definition.json
+++ b/edge/services/sdr/horizon/service.definition.json
@@ -2,7 +2,7 @@
   "org": "$HZN_ORG_ID",
   "label": "$SERVICE_NAME for $ARCH",
   "description": "Provides a REST API to capture 30 second clips of FM radio",
-  "public": true,
+  "public": false,
   "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/sdr/README.md",
   "url": "$SERVICE_NAME",
   "version": "$SERVICE_VERSION",

--- a/edge/services/speedtest/horizon/service.definition.json
+++ b/edge/services/speedtest/horizon/service.definition.json
@@ -2,7 +2,7 @@
   "org": "IBM",
   "label": "Speedtest for ${ARCH}",
   "description": "Speedtest REST API Service",
-  "public": true,
+  "public": false,
   "documentation": "http://github.com/open-horizon/examples/tree/master/edge/services/speedtest/README.md",
   "url": "github.com.open-horizon.examples.speedtest",
   "version": "${VERSION}",

--- a/edge/services/stopword_removal/horizon/service.definition.json
+++ b/edge/services/stopword_removal/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Sample Horizon service that removes stopwords listed in stopwordremoval.py",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/stopword_removal/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/text2speech/horizon/service.definition.json
+++ b/edge/services/text2speech/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Speech to text service using offline Espeak Tool",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/text2speech/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/voice2audio/horizon/service.definition.json
+++ b/edge/services/voice2audio/horizon/service.definition.json
@@ -2,7 +2,7 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME",
     "description": "Vocie to Audio service",
-    "public": true,
+    "public": false,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/voice2audio/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/weatherstation/horizon/microservice.definition.json
+++ b/edge/services/weatherstation/horizon/microservice.definition.json
@@ -2,7 +2,7 @@
   "org": "$HZN_ORG_ID",
   "label": "$PWSMS_NAME for $ARCH",
   "description": "",
-  "public": true,
+  "public": false,
   "specRef": "https://$MYDOMAIN/microservices/$PWSMS_NAME",
   "version": "$PWSMS_VERSION",
   "arch": "$ARCH",

--- a/tools/exchangePublish.sh
+++ b/tools/exchangePublish.sh
@@ -161,6 +161,14 @@ do
     if [[ $EXCLUDE_IBM_PUBLISH != 'true' ]]; then
         echo "Publishing services and patterns of $sample to IBM org..."
         if [[ $EXAMPLES_PREVIEW_MODE != 'true' ]]; then
+            serviceDefinitionFiles=(horizon/service.definition.json horizon/pattern-all-arches.json horizon/pattern.json)
+            for sd in ${serviceDefinitionFiles[@]};
+            do
+                if [[ -f $sd ]]; then
+                    tmpfile=$(mktemp) && jq '.public = true' $sd > tmpfile && mv tmpfile $sd && rm "$tmpfile"
+                    chk $? "modifying horizon metadata file $sd"
+                fi
+            done
             runCmdQuietly make publish-only
         fi
     fi


### PR DESCRIPTION
Partially addresses #356 

This commit changes the up-to-date services default to `"public": false` in their service definition files, so if people copy them by default they will not accidentally expose their services to people outside their org. The examples published to the IBM org must be public, so I also changed the `exchangePublish.sh` script to make the examples `"public": true` right before they are published. The approach is described in more detail [here](https://github.com/open-horizon/examples/issues/356#issuecomment-644694359).

Tested by:

1. Cloning the `examples` repo into `/tmp/open-horizon` (where `exchangePublish.sh` also pulls in the repo`)
2. Updating the up-to-date (ie everything except `wiotp` examples) services there to be `"public": false`
3. Running `./exchangePublish.sh -c myorg`
4. Checking all services listed under `hzn exchange service list IBM/` had `"public": true`. 

Signed-off-by: Clement Ng <clementdng@gmail.com>