### PR TITLE
Remove "public" field from services

### DIFF
--- a/edge/evtstreams/cpu2evtstreams/CreateService.md
+++ b/edge/evtstreams/cpu2evtstreams/CreateService.md
@@ -62,33 +62,41 @@ cd ~   # or wherever you want
 git clone git@github.com:open-horizon/examples.git
 ```
 
-2. Copy the `cpu2evtstreams` dir to where you will start development of your new service:
+2. Checkout the branch that corresponds to your horizon CLI version. To get the branch name, remove the last bullet and any numbers after it, then prepend a `v` at the beginning:
+```bash
+$ hzn version
+Horizon CLI version: 2.27.0-173 # Branch name in this example is v2.27
+Horizon Agent version: 2.27.0-173
+$ git checkout v2.27
+```
+
+3. Copy the `cpu2evtstreams` dir to where you will start development of your new service:
 ```bash
 cp -a examples/edge/evtstreams/cpu2evtstreams ~/myservice     # or wherever
 cd ~/myservice
 ```
 
-3. Set the values in `horizon/hzn.json` to your own values.
+4. Set the values in `horizon/hzn.json` to your own values.
 
-4. Edit `service.sh` however you want.
+5. Edit `service.sh` however you want.
     - Note: this service is a shell script simply for brevity, but you can write your service in any language.
 
-5. Build the cpu2evtstreams docker image:
+6. Build the cpu2evtstreams docker image:
 ```bash
 make
 ```
 
-6. Test the service by having Horizon start it locally:
+7. Test the service by having Horizon start it locally:
 ```bash
 hzn dev service start -S
 ```
 
-7. Check that the container is running:
+8. Check that the container is running:
 ```bash
 sudo docker ps 
 ```
 
-8. See the cpu2evtstreams service output:
+9. See the cpu2evtstreams service output:
 
  	on **Linux**:
  	```
@@ -100,17 +108,17 @@ sudo docker ps
  	docker logs -f $(docker ps -q --filter name=cpu2evtstreams)
  	``` 
 
-9. See the environment variables Horizon passes into your service container:
+10. See the environment variables Horizon passes into your service container:
 ```bash
 docker inspect $(docker ps -q --filter name=cpu2evtstreams) | jq '.[0].Config.Env'
 ```
 
-10. Stop the service:
+11. Stop the service:
 ```bash
 hzn dev service stop
 ```
 
-11. Have Horizon push your docker image to your registry and publish your service in the Horizon Exchange and see it there:
+12. Have Horizon push your docker image to your registry and publish your service in the Horizon Exchange and see it there:
 ```bash
 hzn exchange service publish -f horizon/service.definition.json
 hzn exchange service list

--- a/edge/evtstreams/cpu2evtstreams/Makefile
+++ b/edge/evtstreams/cpu2evtstreams/Makefile
@@ -72,7 +72,7 @@ publish-all-arches:
 
 # target for script - overwrite and pull insitead of push docker image
 publish-service-overwrite:
-	hzn exchange service publish -O -P -f horizon/service.definition.json
+	hzn exchange service publish -O -P --public=true -f horizon/service.definition.json
 
 # Publish Service Policy target for exchange publish script
 publish-service-policy:

--- a/edge/evtstreams/cpu2evtstreams/horizon/service.definition.json
+++ b/edge/evtstreams/cpu2evtstreams/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Sample Horizon service that repeatedly reads the CPU load and GPS location, and sends it to IBM Event Streams",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/evtstreams/cpu2evtstreams/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/evtstreams/sdr2evtstreams/CreateService.md
+++ b/edge/evtstreams/sdr2evtstreams/CreateService.md
@@ -62,85 +62,93 @@ cd ~   # or wherever you want
 git clone git@github.com:open-horizon/examples.git
 ```
 
-2. Copy the `sdr2evtstreams` dir to where you will start development of your new service:
+2. Checkout the branch that corresponds to your horizon CLI version. To get the branch name, remove the last bullet and any numbers after it, then prepend a `v` at the beginning:
+```bash
+$ hzn version
+Horizon CLI version: 2.27.0-173 # Branch name in this example is v2.27
+Horizon Agent version: 2.27.0-173
+$ git checkout v2.27
+```
+
+3. Copy the `sdr2evtstreams` dir to where you will start development of your new service:
 ```bash
 cp -a examples/edge/evtstreams/sdr2evtstreams ~/myservice     # or wherever
 cd ~/myservice
 ```
 
-3. Set the values in `horizon/hzn.json` to your own values.
+4. Set the values in `horizon/hzn.json` to your own values.
 
-4. Edit `main.go` however you want.
+5. Edit `main.go` however you want.
     - Note: this service is written in go, but you can write your service in any language.
 
-5. Build the sdr2evtstreams docker image:
+6. Build the sdr2evtstreams docker image:
 ```bash
 make
 ```
 
-6. Test the service by having Horizon start it locally:
+7. Test the service by having Horizon start it locally:
 ```bash
 hzn dev service start -S
 ```
 
-7. Check that the containers are running:
+8. Check that the containers are running:
 ```bash
 sudo docker ps
 ```
 
-8. See the sdr2evtstreams service output:
+9. See the sdr2evtstreams service output:
 ```bash
 hzn service log -f ibm.sdr2evtstreams
 ```
 
-9. See the environment variables Horizon passes into your service container:
+10. See the environment variables Horizon passes into your service container:
 ```bash
 docker inspect $(docker ps -q --filter name=sdr2evtstreams) | jq '.[0].Config.Env'
 ```
 
-10. Stop the service:
+11. Stop the service:
 ```bash
 hzn dev service stop
 ```
 
-11. Have Horizon push your docker image to your registry and publish your service in the Horizon Exchange and see it there:
+12. Have Horizon push your docker image to your registry and publish your service in the Horizon Exchange and see it there:
 ```bash
 hzn exchange service publish -f horizon/service.definition.json
 hzn exchange service list
 ```
 
-12. Publish your edge node deployment pattern in the Horizon Exchange and see it there:
+13. Publish your edge node deployment pattern in the Horizon Exchange and see it there:
 ```bash
 hzn exchange pattern publish -f horizon/pattern.json
 hzn exchange pattern list
 ```
 
-13. Register your edge node with Horizon to use your deployment pattern (substitute `<service-name>` for the `SERVICE_NAME` you specified in `horizon/hzn.json`):
+14. Register your edge node with Horizon to use your deployment pattern (substitute `<service-name>` for the `SERVICE_NAME` you specified in `horizon/hzn.json`):
 ```bash
 hzn register -p pattern-<service-name>-$(hzn architecture) -f horizon/userinput.json
 ```
 
-14. The edge device will make an agreement with one of the Horizon agreement bots (this typically takes about 15 seconds). Repeatedly query the agreements of this device until the `agreement_finalized_time` and `agreement_execution_start_time` fields are filled in:
+15. The edge device will make an agreement with one of the Horizon agreement bots (this typically takes about 15 seconds). Repeatedly query the agreements of this device until the `agreement_finalized_time` and `agreement_execution_start_time` fields are filled in:
 ```bash
 hzn agreement list
 ```
 
-15. Once the agreement is made, list the docker container edge service that has been started as a result:
+16. Once the agreement is made, list the docker container edge service that has been started as a result:
 ```bash
 sudo docker ps
 ```
 
-16. On any machine, subscribe to the Event Streams topic to see the json data that sdr2evtstreams is sending:
+17. On any machine, subscribe to the Event Streams topic to see the json data that sdr2evtstreams is sending:
 ```bash
 kafkacat -C -q -o end -f "%t/%p/%o/%k: %s\n" -b $EVTSTREAMS_BROKER_URL -X api.version.request=true -X security.protocol=sasl_ssl -X sasl.mechanisms=PLAIN -X sasl.username=token -X sasl.password=$EVTSTREAMS_API_KEY -t $EVTSTREAMS_TOPIC
 ```
 
-17. See the sdr2evtstreams service output:
+18. See the sdr2evtstreams service output:
 ```bash
 hzn service log -f ibm.sdr2evtstreams
 ```
 
-18. Unregister your edge node, stopping the sdr2evtstreams service:
+19. Unregister your edge node, stopping the sdr2evtstreams service:
 ```bash
 hzn unregister -f
 ```

--- a/edge/evtstreams/sdr2evtstreams/horizon/service.definition.json
+++ b/edge/evtstreams/sdr2evtstreams/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Sample Horizon service that sends 30 second clips of FM radio rich in speech to IBM Event Streams",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/evtstreams/sdr2evtstreams/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/evtstreams/watson_speech2text/CreateService.md
+++ b/edge/evtstreams/watson_speech2text/CreateService.md
@@ -62,82 +62,90 @@ cp -a examples/edge/evtstreams/watson_speech2text ~/myservice     # or wherever
 cd ~/myservice
 ```
 
-3. Set the values in `horizon/hzn.json` to your own values.
+3. Checkout the branch that corresponds to your horizon CLI version. To get the branch name, remove the last bullet and any numbers after it, then prepend a `v` at the beginning:
+```bash
+$ hzn version
+Horizon CLI version: 2.27.0-173 # Branch name in this example is v2.27
+Horizon Agent version: 2.27.0-173
+$ git checkout v2.27
+```
 
-4. Edit `watsonspeech2text.py` however you want.
+4. Set the values in `horizon/hzn.json` to your own values.
+
+5. Edit `watsonspeech2text.py` however you want.
     - Note: this service is a shell script simply for brevity, but you can write your service in any language.
-5. Build the watsons2text docker image:
+6. Build the watsons2text docker image:
 
 ```bash
 make
 ```
 
-6. Test the service by having Horizon start it locally:
+7. Test the service by having Horizon start it locally:
 ```bash
 hzn dev service start -S
 ```
-7. Check that the container is running:
+8. Check that the container is running:
 ```bash
 sudo docker ps 
 ```
 
-8. See the watsons2text service output:
+9. See the watsons2text service output:
 
 	```bash
 	tail -f /var/log/syslog | grep watsons2text[[]
 	```
 
-9. See the environment variables Horizon passes into your service container:
+10. See the environment variables Horizon passes into your service container:
 ```bash
 docker inspect $(docker ps -q --filter name=watsons2text) | jq '.[0].Config.Env'
 ```
 
-10. Stop the service:
+11. Stop the service:
 ```bash
 hzn dev service stop
 ```
 
-11. Have Horizon push your docker image to your registry and publish your service in the Horizon Exchange and see it there:
+12. Have Horizon push your docker image to your registry and publish your service in the Horizon Exchange and see it there:
 ```bash
 hzn exchange service publish -f horizon/service.definition.json
 hzn exchange service list
 ```
 
-12. Publish your edge node deployment pattern in the Horizon Exchange and see it there:
+13. Publish your edge node deployment pattern in the Horizon Exchange and see it there:
 ```bash
 hzn exchange pattern publish -f horizon/pattern.json
 hzn exchange pattern list
 ```
 
-13. Register your edge node with Horizon to use your deployment pattern (substitute `<service-name>` for the `SERVICE_NAME` you specified in `horizon/hzn.json`):
+14. Register your edge node with Horizon to use your deployment pattern (substitute `<service-name>` for the `SERVICE_NAME` you specified in `horizon/hzn.json`):
 ```bash
 hzn register -p pattern-<service-name>-$(hzn architecture) -f horizon/userinput.json
 ```
 
-14. The edge device will make an agreement with one of the Horizon agreement bots (this typically takes about 15 seconds). Repeatedly query the agreements of this device until the `agreement_finalized_time` and `agreement_execution_start_time` fields are filled in:
+15. The edge device will make an agreement with one of the Horizon agreement bots (this typically takes about 15 seconds). Repeatedly query the agreements of this device until the `agreement_finalized_time` and `agreement_execution_start_time` fields are filled in:
 ```bash
 hzn agreement list
 ```
 
-15. Once the agreement is made, list the docker container edge service that has been started as a result:
+16. Once the agreement is made, list the docker container edge service that has been started as a result:
 ```bash
 sudo docker ps
 ```
 
 
-16. On any machine, install [kafkacat](https://github.com/edenhill/kafkacat#install), then subscribe to the Event Streams topic to see the json data that watsons2text is sending:
+17. On any machine, install [kafkacat](https://github.com/edenhill/kafkacat#install), then subscribe to the Event Streams topic to see the json data that watsons2text is sending:
 
 ```bash
 kafkacat -C -q -o end -f "%t/%p/%o/%k: %s\n" -b $EVTSTREAMS_BROKER_URL -X api.version.request=true -X security.protocol=sasl_ssl -X sasl.mechanisms=PLAIN -X sasl.username=token -X sasl.password=$EVTSTREAMS_API_KEY -X ssl.ca.location=$EVTSTREAMS_CERT_FILE -t $EVTSTREAMS_TOPIC
 ```
 
 
-17. See the watsons2text service output:
+18. See the watsons2text service output:
 ```bash
 tail -f /var/log/syslog | grep watsons2text[[]
 ``` 
 
-18. Unregister your edge node, stopping the watsons2text service:
+19. Unregister your edge node, stopping the watsons2text service:
 ```bash
 hzn unregister -f
 ```

--- a/edge/evtstreams/watson_speech2text/horizon/service.definition.json
+++ b/edge/evtstreams/watson_speech2text/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "zhangl - A super-simple sample Horizon service",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/msghub/watson_speech2text/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/audio2text/horizon/service.definition.json
+++ b/edge/services/audio2text/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME",
     "description": "Audio to Text service",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/audio2text/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/cpu_percent/Makefile
+++ b/edge/services/cpu_percent/Makefile
@@ -56,7 +56,7 @@ publish-all-arches:
 
 # target for script - overwrite and pull insitead of push docker image
 publish-service-overwrite:
-	hzn exchange service publish -O -P -f horizon/service.definition.json
+	hzn exchange service publish -O -P --public=true -f horizon/service.definition.json
 
 # new target for new exchange to run on startup to publish only
 publish-only:

--- a/edge/services/cpu_percent/horizon/service.definition.json
+++ b/edge/services/cpu_percent/horizon/service.definition.json
@@ -2,7 +2,6 @@
   "org": "$HZN_ORG_ID",
   "label": "$SERVICE_NAME for $ARCH",
   "description": "Provides a REST API to query the CPU percent",
-  "public": true,
   "documentation": "https://github.com/open-horizon/examples/tree/master/edge/services/cpu_percent/README.md",
   "url": "$SERVICE_NAME",
   "version": "$SERVICE_VERSION",

--- a/edge/services/gps/Makefile
+++ b/edge/services/gps/Makefile
@@ -60,7 +60,7 @@ publish-all-arches:
 
 # target for script - overwrite and pull insitead of push docker image
 publish-service-overwrite:
-	hzn exchange service publish -O -P -f horizon/service.definition.json
+	hzn exchange service publish -O -P --public=true -f horizon/service.definition.json
 
 # new target for icp exchange to run on startup to publish only
 publish-only:

--- a/edge/services/gps/horizon/service.definition.json
+++ b/edge/services/gps/horizon/service.definition.json
@@ -2,7 +2,6 @@
   "org": "$HZN_ORG_ID",
   "label": "$SERVICE_NAME for $ARCH",
   "description": "Provides the edge node location via a REST API from a GPS sensor, environment variables, or the IP address",
-  "public": true,
   "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/gps/README.md",
   "url": "$SERVICE_NAME",
   "version": "$SERVICE_VERSION",

--- a/edge/services/helloMMS/CreateService.md
+++ b/edge/services/helloMMS/CreateService.md
@@ -61,49 +61,57 @@ Follow the steps in this page to create your first Horizon edge service that use
   cd ~   # or wherever you want
   git clone git@github.com:open-horizon/examples.git
   ```
+2. Checkout the branch that corresponds to your horizon CLI version. To get the branch name, remove the last bullet and any numbers after it, then prepend a `v` at the beginning:
 
-2. Copy the `hello-mms` dir to where you will start development of your new service:
+  ```bash
+  $ hzn version
+  Horizon CLI version: 2.27.0-173 # Branch name in this example is v2.27
+  Horizon Agent version: 2.27.0-173
+  $ git checkout v2.27
+  ```
+
+3. Copy the `hello-mms` dir to where you will start development of your new service:
 
   ```bash
   cp -a examples/edge/services/helloMMS ~/myservice     # or wherever
   cd ~/myservice
   ```
 
-3. Set the values in `horizon/hzn.json` to your liking. These variables are used in the service and pattern files in `horizon` and in the MMS metadata file `object.json`. They are also used in some of the commands in this procedure. After editing `horizon/hzn.json`, set the variables in your environment:
+4. Set the values in `horizon/hzn.json` to your liking. These variables are used in the service and pattern files in `horizon` and in the MMS metadata file `object.json`. They are also used in some of the commands in this procedure. After editing `horizon/hzn.json`, set the variables in your environment:
 
   ```bash
   eval $(hzn util configconv -f horizon/hzn.json)
   ```
 
-4. Edit `service.sh` however you want. For example, to make a simple change so you will be able to confirm that your new service is running, you could customize the `echo` statement near the end that says "Hello". While you are editing `service.sh`, read the comments and code to learn the basic pattern for using a MMS file in an edge service. This coding pattern will be the same, regardless of what language you implement your own edge services in.
+5. Edit `service.sh` however you want. For example, to make a simple change so you will be able to confirm that your new service is running, you could customize the `echo` statement near the end that says "Hello". While you are editing `service.sh`, read the comments and code to learn the basic pattern for using a MMS file in an edge service. This coding pattern will be the same, regardless of what language you implement your own edge services in.
     - Note: this service is a shell script simply for brevity, but you can write your service in any language.
 
-5. Build the service docker image. Note that the Dockerfiles copy `config.json` into the service image for it to initially use.
+6. Build the service docker image. Note that the Dockerfiles copy `config.json` into the service image for it to initially use.
 
   ```bash
   make
   ```
 
-6. Test the service by running it the simulated agent environment. (`HZN_PATTERN` is set so the simulated environment can find MMS object in subsequent steps.)
+7. Test the service by running it the simulated agent environment. (`HZN_PATTERN` is set so the simulated environment can find MMS object in subsequent steps.)
 
   ```bash
   export HZN_PATTERN=pattern-${SERVICE_NAME}-$(hzn architecture)
   hzn dev service start
   ```
 
-7. Check that the container is running:
+8. Check that the container is running:
 
   ```bash
   sudo docker ps
   ```
 
-8. Display the environment variables Horizon passes into your service container. Note the variables that start with `HZN_ESS_`. These are used by the service to contact the local MMS proxy.
+9. Display the environment variables Horizon passes into your service container. Note the variables that start with `HZN_ESS_`. These are used by the service to contact the local MMS proxy.
 
   ```bash
   sudo docker inspect $(sudo docker ps -q --filter name=$SERVICE_NAME) | jq '.[0].Config.Env'
   ```
 
-9. **Open another terminal to the same working directory** then set the `horizon/hzn.json` variable values in this environment and view the service output (you should see messages like **\<your-node-id\> says: Hello from the dockerfile!**:
+10. **Open another terminal to the same working directory** then set the `horizon/hzn.json` variable values in this environment and view the service output (you should see messages like **\<your-node-id\> says: Hello from the dockerfile!**:
 
   on **Linux**:
 
@@ -119,7 +127,7 @@ Follow the steps in this page to create your first Horizon edge service that use
   sudo docker logs -f $(sudo docker ps -q --filter name=$SERVICE_NAME)
   ```
 
-10. While observing the output in the other terminal, modify `config.json` and publish it as a new mms object, using the provided `object.json` metadata. Since you are running in the local simulated agent environment right now, the `hzn mms ...` commands must be directed to the local MMS.
+11. While observing the output in the other terminal, modify `config.json` and publish it as a new mms object, using the provided `object.json` metadata. Since you are running in the local simulated agent environment right now, the `hzn mms ...` commands must be directed to the local MMS.
 
   ```bash
   jq '.HW_WHO = "from the MMS"' config.json > config.tmp && mv config.tmp config.json
@@ -127,7 +135,7 @@ Follow the steps in this page to create your first Horizon edge service that use
   HZN_FSS_CSSURL=http://localhost:8580  hzn mms object publish -m object.json -f config.json
   ```
 
-11. View the published mms object:
+12. View the published mms object:
 
   ```bash
   HZN_FSS_CSSURL=http://localhost:8580  hzn mms object list -d
@@ -135,26 +143,26 @@ Follow the steps in this page to create your first Horizon edge service that use
 
   Once the `Object status` changes to `delivered` you will see the output of the hello-mms service (in the other terminal) change from **\<your-node-id\> says: Hello from the dockerfile!** to **\<your-node-id\> says: Hello from the MMS!**
 
-12. Delete your MMS object and watch the service messages change back to the original value:
+13. Delete your MMS object and watch the service messages change back to the original value:
 
   ```bash
   HZN_FSS_CSSURL=http://localhost:8580  hzn mms object delete -t $HZN_DEVICE_ID.hello-mms -i config.json
   ```
 
-13. Stop the service:
+14. Stop the service:
 
   ```bash
   hzn dev service stop
   ```
 
-14. You are now ready to publish your edge service and pattern, so that they can be deployed to real edge nodes. Instruct Horizon to push your docker image to your registry and publish your service in the Horizon Exchange:
+15. You are now ready to publish your edge service and pattern, so that they can be deployed to real edge nodes. Instruct Horizon to push your docker image to your registry and publish your service in the Horizon Exchange:
 
   ```bash
   hzn exchange service publish -f horizon/service.definition.json
   hzn exchange service list
   ```
 
-15. Edit your pattern definition file to make the pattern not public, then publish your edge node deployment pattern in the Horizon Exchange:
+16. Edit your pattern definition file to make the pattern not public, then publish your edge node deployment pattern in the Horizon Exchange:
 
   ```bash
   jq '.public = false' horizon/pattern.json > horizon/pattern.tmp && mv horizon/pattern.tmp horizon/pattern.json
@@ -162,33 +170,33 @@ Follow the steps in this page to create your first Horizon edge service that use
   hzn exchange pattern list
   ```
 
-16. Register your edge node with Horizon to use your deployment pattern:
+17. Register your edge node with Horizon to use your deployment pattern:
 
   ```bash
   hzn register -p pattern-${SERVICE_NAME}-$(hzn architecture) -s $SERVICE_NAME --serviceorg $HZN_ORG_ID
   ```
 
-17. Switch back to your **other terminal** and again view the service output with the "follow" flag:
+18. Switch back to your **other terminal** and again view the service output with the "follow" flag:
 
   ```bash
   hzn service log -f $SERVICE_NAME
   ```
   
-18. While observing the output in the other terminal, publish `config.json` as a new object in the cloud MMS:
+19. While observing the output in the other terminal, publish `config.json` as a new object in the cloud MMS:
 
   ```bash
   hzn mms object publish -m object.json -f config.json
   ```
 
-19. View the published mms object:
+20. View the published mms object:
 
   ```bash
   hzn mms object list -t $HZN_DEVICE_ID.hello-mms -i config.json -d
   ```
 
-20. After approximately 15 seconds you should see the output of the service change to the value of `HW_WHO` set in the `config.json` file.
+21. After approximately 15 seconds you should see the output of the service change to the value of `HW_WHO` set in the `config.json` file.
 
-21. Clean up by deleting the published mms object and unregistering your edge node:
+22. Clean up by deleting the published mms object and unregistering your edge node:
 
   ```bash
   hzn mms object delete -t $HZN_DEVICE_ID.hello-mms -i config.json

--- a/edge/services/helloMMS/Makefile
+++ b/edge/services/helloMMS/Makefile
@@ -60,7 +60,7 @@ publish-all-arches:
 
 # target for script - overwrite and pull insitead of push docker image
 publish-service-overwrite:
-	hzn exchange service publish -O -P -f horizon/service.definition.json
+	hzn exchange service publish -O -P --public=true -f horizon/service.definition.json
 
 # target to publish new input.json file to mms
 publish-mms-object:

--- a/edge/services/helloMMS/horizon/service.definition.json
+++ b/edge/services/helloMMS/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "A super-simple sample Horizon service",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/helloworld/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/helloworld/Makefile
+++ b/edge/services/helloworld/Makefile
@@ -69,7 +69,7 @@ publish-all-arches:
 
 # target for script - overwrite and pull insitead of push docker image
 publish-service-overwrite:
-	hzn exchange service publish -O -P -f horizon/service.definition.json
+	hzn exchange service publish -O -P --public=true -f horizon/service.definition.json
 
 # Publish Service Policy target for exchange publish script
 publish-service-policy:

--- a/edge/services/helloworld/horizon/service.definition.json
+++ b/edge/services/helloworld/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "A super-simple sample Horizon service",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/helloworld/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/hotword_detection/horizon/service.definition.json
+++ b/edge/services/hotword_detection/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "zhangl - A super-simple sample Horizon service",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/hotword_detection/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/mqtt2kafka/horizon/service.definition.json
+++ b/edge/services/mqtt2kafka/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Sample Horizon service that receives data via MQTT broker and sends it to IBM Event Streams",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/mqtt2kafka/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/mqtt_broker/horizon/service.definition.json
+++ b/edge/services/mqtt_broker/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "An mqtt broker and publisher for inter-container commmunication",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/mqtt_broker/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/nginx-operator/Makefile
+++ b/edge/services/nginx-operator/Makefile
@@ -30,7 +30,7 @@ publish-all-arches: test-publish
 
 # target for script - overwrite and pull insitead of push docker image
 publish-service-overwrite:
-	hzn exchange service publish -O -P -f horizon/service.definition.json
+	hzn exchange service publish -O -P --public=true -f horizon/service.definition.json
 
 # Publish Service Policy target for exchange publish script
 publish-service-policy:

--- a/edge/services/nginx-operator/horizon/service.definition.json
+++ b/edge/services/nginx-operator/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "",
-    "public": true,
     "documentation": "",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/pi3_streamer/horizon/microservice.definition.json
+++ b/edge/services/pi3_streamer/horizon/microservice.definition.json
@@ -2,7 +2,6 @@
   "org": "$HZN_ORG_ID",
   "label": "$PI3STREAMER_NAME for $ARCH",
   "description": "Provides a stream endpoint on LAN from a RPi3 camera feed (RPi Cam)",
-  "public": true,
   "specRef": "https://$MYDOMAIN/microservices/$PI3STREAMER_NAME",
   "version": "$PI3STREAMER_VERSION",
   "arch": "$ARCH",

--- a/edge/services/processtext/CreateService.md
+++ b/edge/services/processtext/CreateService.md
@@ -61,81 +61,89 @@ cd ~   # or wherever you want
 git clone git@github.com:open-horizon/examples.git
 ```
 
-2. Copy the `processtext` dir to where you will start development of your new service:
+2. Checkout the branch that corresponds to your horizon CLI version. To get the branch name, remove the last bullet and any numbers after it, then prepend a `v` at the beginning:
+```bash
+$ hzn version
+Horizon CLI version: 2.27.0-173 # Branch name in this example is v2.27
+Horizon Agent version: 2.27.0-173
+$ git checkout v2.27
+```
+
+3. Copy the `processtext` dir to where you will start development of your new service:
 ```bash
 cp -a examples/edge/services/processtext ~/myservice     # or wherever
 cd ~/myservice
 ```
 
-3. Set the values in `horizon/hzn.json` to your own values.
+4. Set the values in `horizon/hzn.json` to your own values.
 
-4. Edit `processtext.sh` however you want.
+5. Edit `processtext.sh` however you want.
     - Note: This service is a shell script for brevity, but you can write your service in any language.
 
-5. Build the processtext docker image:
+6. Build the processtext docker image:
 ```bash
 make
 ```
 
-6. Test the service by having Horizon start it locally:
+7. Test the service by having Horizon start it locally:
 ```bash
 hzn dev service start -S
 ```
 
-7. Check that the container is running:
+8. Check that the container is running:
 ```bash
 sudo docker ps 
 ```
 
-8. See the processtext service output:
+9. See the processtext service output:
 ```bash
 tail -f /var/log/syslog | grep OVA
 ```
 
-9. See the environment variables Horizon passes into your service container:
+10. See the environment variables Horizon passes into your service container:
 ```bash
 docker inspect $(docker ps -q --filter name=ibm.processtext) | jq '.[0].Config.Env'
 ```
 
-10. Stop the service:
+11. Stop the service:
 ```bash
 hzn dev service stop
 ```
 
-11. Have Horizon push your docker image to your registry and publish your service in the Horizon Exchange and see it there:
+12. Have Horizon push your docker image to your registry and publish your service in the Horizon Exchange and see it there:
 ```bash
 hzn exchange service publish -f horizon/service.definition.json
 hzn exchange service list
 ```
 
-12. Publish your edge node deployment pattern in the Horizon Exchange and see it there:
+13. Publish your edge node deployment pattern in the Horizon Exchange and see it there:
 ```bash
 hzn exchange pattern publish -f horizon/pattern.json
 hzn exchange pattern list
 ```
 
-13. Register your edge node with Horizon to use your deployment pattern (substitute `<service-name>` for the `SERVICE_NAME` you specified in `horizon/hzn.json`):
+14. Register your edge node with Horizon to use your deployment pattern (substitute `<service-name>` for the `SERVICE_NAME` you specified in `horizon/hzn.json`):
 ```bash
 hzn register -p pattern-<service-name>-$(hzn architecture) -f horizon/userinput.json
 ```
 
-14. The edge device will make an agreement with one of the Horizon agreement bots (this typically takes about 15 seconds). Repeatedly query the agreements of this device until the `agreement_finalized_time` and `agreement_execution_start_time` fields are filled in:
+15. The edge device will make an agreement with one of the Horizon agreement bots (this typically takes about 15 seconds). Repeatedly query the agreements of this device until the `agreement_finalized_time` and `agreement_execution_start_time` fields are filled in:
 ```bash
 hzn agreement list
 ```
 
-15. Once the agreement is made, list the docker container edge service that has been started as a result:
+16. Once the agreement is made, list the docker container edge service that has been started as a result:
 ```bash
 sudo docker ps
 ```
 
-16. See the processtext service output:
+17. See the processtext service output:
 
 	```
 	tail -f /var/log/syslog | grep OVA
 	```
 
-17. Unregister your edge node, stopping the processtext service:
+18. Unregister your edge node, stopping the processtext service:
 ```
 hzn unregister -f
 ```

--- a/edge/services/processtext/horizon/service.definition.json
+++ b/edge/services/processtext/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME",
     "description": "Sample Horizon service that acts as an Offline Voice Assistant",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/processtext/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/sdr/horizon/service.definition.json
+++ b/edge/services/sdr/horizon/service.definition.json
@@ -2,7 +2,6 @@
   "org": "$HZN_ORG_ID",
   "label": "$SERVICE_NAME for $ARCH",
   "description": "Provides a REST API to capture 30 second clips of FM radio",
-  "public": true,
   "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/sdr/README.md",
   "url": "$SERVICE_NAME",
   "version": "$SERVICE_VERSION",

--- a/edge/services/stopword_removal/horizon/service.definition.json
+++ b/edge/services/stopword_removal/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Sample Horizon service that removes stopwords listed in stopwordremoval.py",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/stopword_removal/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/text2speech/horizon/service.definition.json
+++ b/edge/services/text2speech/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME for $ARCH",
     "description": "Speech to text service using offline Espeak Tool",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/text2speech/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/voice2audio/horizon/service.definition.json
+++ b/edge/services/voice2audio/horizon/service.definition.json
@@ -2,7 +2,6 @@
     "org": "$HZN_ORG_ID",
     "label": "$SERVICE_NAME",
     "description": "Vocie to Audio service",
-    "public": true,
     "documentation": "https://github.com/open-horizon/examples/blob/master/edge/services/voice2audio/README.md",
     "url": "$SERVICE_NAME",
     "version": "$SERVICE_VERSION",

--- a/edge/services/weatherstation/horizon/microservice.definition.json
+++ b/edge/services/weatherstation/horizon/microservice.definition.json
@@ -2,7 +2,6 @@
   "org": "$HZN_ORG_ID",
   "label": "$PWSMS_NAME for $ARCH",
   "description": "",
-  "public": true,
   "specRef": "https://$MYDOMAIN/microservices/$PWSMS_NAME",
   "version": "$PWSMS_VERSION",
   "arch": "$ARCH",


### PR DESCRIPTION
Partially addresses #356 

This commit removes the "public" field from the service definition files of the up-to-date services. As discussed in this [comment](https://github.com/open-horizon/examples/issues/356#issuecomment-731166634), the "public" field should be moved out of the service definition files since it isn't tied tightly to the service image implementation. Instead, the "public" field will be set by a flag set by the `hzn exchange publish service` command instead. 

To make sure the changes are backwards compatible, there's an instruction in the README's to set the examples branch equal to the user's horizon CLI branch. To ensure that the `exchangePublish.sh` script continues functioning as normal, I've updated the `publish-only` Makefile targets of the `blessedSamples` to use the new anax flag to set "public" to true.

Signed-off-by: Clement Ng <clementdng@gmail.com>