### PR TITLE
Remove branch checkout instruction

### DIFF
--- a/edge/services/sdr/Dockerfile.amd64
+++ b/edge/services/sdr/Dockerfile.amd64
@@ -3,7 +3,6 @@ RUN apk --no-cache add git cmake libusb-dev make gcc g++ alpine-sdk
 WORKDIR /tmp
 RUN git clone https://github.com/clementkng/librtlsdr
 WORKDIR /tmp/librtlsdr
-RUN git checkout rpc
 
 RUN mkdir build && cd build && cmake ../ && make && make install
 RUN ls /usr/local/bin/rtl_*

--- a/edge/services/sdr/Dockerfile.arm
+++ b/edge/services/sdr/Dockerfile.arm
@@ -3,7 +3,6 @@ RUN apk --no-cache add git cmake libusb-dev make gcc g++ alpine-sdk
 WORKDIR /tmp
 RUN git clone https://github.com/clementkng/librtlsdr
 WORKDIR /tmp/librtlsdr
-RUN git checkout rpc
 
 RUN mkdir build && cd build && cmake ../ -DINSTALL_UDEV_RULES=ON -DDETACH_KERNEL_DRIVER=ON && make && make install
 RUN ls /usr/local/bin/rtl_*

--- a/edge/services/sdr/Dockerfile.arm64
+++ b/edge/services/sdr/Dockerfile.arm64
@@ -3,7 +3,6 @@ RUN apk --no-cache add git cmake libusb-dev make gcc g++ alpine-sdk
 WORKDIR /tmp
 RUN git clone https://github.com/clementkng/librtlsdr
 WORKDIR /tmp/librtlsdr
-RUN git checkout rpc
 
 RUN mkdir build && cd build && cmake ../ && make && make install
 RUN ls /usr/local/bin/rtl_*


### PR DESCRIPTION
Remove the branch checkout instruction from the sdr Dockerfiles, since I've merged the `rpc` branch into the `master` branch in my [librtlsdr](https://github.com/clementkng/librtlsdr/commit/e5e5a1d384da288f1bdce39d5ecaaced148ea93d) fork.

Tested that service still functions as expected.

Signed-off-by: Clement Ng <clementdng@gmail.com>