### PR TITLE
Update sdr docs with instructions for listening to audio with the play command

### DIFF
--- a/edge/services/sdr/README.md
+++ b/edge/services/sdr/README.md
@@ -23,3 +23,7 @@ Get a 30 second chunk of raw audio.
 If the SDR hardware is not present or can not be used for some reason you can curl the fake station at frequency 0, which will call out to BBC radio online.
 
 `curl ibm.sdr:8080/audio/0 | aplay -r 16000 -f S16_LE -t raw -c 1`
+
+If your device doesn't support the `aplay` command (ie Mac), you can also use the `play` command.
+
+`curl ibm.sdr:8080/audio/0 | play --rate 8000 --bits 16 --encoding signed-integer --channels 2 -t raw -`


### PR DESCRIPTION
Now, users can listen to the audio on devices that don't support `aplay`, like Mac.

Signed-off-by: Clement Ng <clementdng@gmail.com>