### PR TITLE
Fix problem with edge cluster service

### DIFF
--- a/tools/loadResources
+++ b/tools/loadResources
@@ -128,11 +128,6 @@ for k_tmp in "${keys[@]}"; do
             if [ ! -z "${deployment}" ]; then 
 		    resourceJson=$(jq ".deployment = $deployment" <<< $resourceJson)
 	    fi
-            clusterDeployment=$(jq -r '.clusterDeployment' <<< $resourceJson)
-            if [ ! -z "${clusterDeployment}" ]; then 
-		    resourceJson=$(jq ".clusterDeployment = $clusterDeployment" <<< $resourceJson)
-	    fi
-	    echo "${resourceJson}"
             echo "$resourceJson" | hzn exchange service publish -I -O -f-
         ;;
         pattern) echo "$resourceJson" | hzn exchange pattern publish -p "$name" -f-


### PR DESCRIPTION
Signed-off-by: Doug Larson <larsond@us.ibm.com>

Inflating the clusterDeployment field called the utility to fail for edge cluster services. 
Resolved that issue by leaving that field as a string