### PR TITLE
Add eclipse files to gitignore

### DIFF
--- a/cloud/sdr/ui/sdr-app/.gitignore
+++ b/cloud/sdr/ui/sdr-app/.gitignore
@@ -2,3 +2,8 @@ node_modules
 node_modules/
 server/config/settings.js
 .eslintrc.json
+
+# Eclipse files
+.classpath
+.project
+.settings/


### PR DESCRIPTION
Fixes #495

Ensures that eclipse project files will not be pushed.

Signed-off-by: Clement Ng <clementdng@gmail.com>