### PR TITLE
Replace deprecated aarch64/alpine container

### DIFF
--- a/edge/services/gps/Dockerfile.arm64
+++ b/edge/services/gps/Dockerfile.arm64
@@ -32,7 +32,7 @@ RUN env GOPATH=/build GOOPTIONS_ARM64='CGO_ENABLED=0 GOOS=linux GOARCH=arm64 ' g
 
 # Build stage 1: The final container (including armv6_gps binary from above)
 
-FROM aarch64/alpine:latest
+FROM arm64v8/alpine:latest
 
 # Install the gpsd daemon, and the certs needed to use https services
 RUN apk update && apk add gpsd curl --no-cache ca-certificates


### PR DESCRIPTION
## Summary of Changes
Replaced the aarch64/alpine container with the arm64v8/alpine container. Addresses issue #558.

## Testing
![dockerbuild](https://user-images.githubusercontent.com/43871629/197366329-24529e58-5f6b-4b3f-9141-789f04064ba3.png)

## Notes
I was having some issues with the tag for the make build command, so I checked the Makefile and just ran that command with a different tag instead.
![issue](https://user-images.githubusercontent.com/43871629/197366443-8c85e1ea-534c-4b41-81d1-3b333c1207e5.png)

