### PR TITLE
Issue 555 : CPU_PERCENT and GPS examples do not expose port

### DIFF
--- a/edge/services/cpu_percent/horizon/service.definition.json
+++ b/edge/services/cpu_percent/horizon/service.definition.json
@@ -12,7 +12,10 @@
   "deployment": {
     "services": {
       "$SERVICE_NAME": {
-        "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION"
+        "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION",
+        "ports": [
+          { "HostIP": "0.0.0.0", "HostPort": "8080:8080/tcp" }
+        ]
       }
     }
   }

--- a/edge/services/gps/horizon/service.definition.json
+++ b/edge/services/gps/horizon/service.definition.json
@@ -49,6 +49,9 @@
         ],
         "devices": [
           "/dev/:/dev/"
+        ],
+        "ports": [ 
+          { "HostIP": "0.0.0.0", "HostPort": "8080:8080/tcp" }
         ]
       }
     }


### PR DESCRIPTION
Exposed ports through `edge/services/cpu_percent/horizon/service.definition.json` and `edge/services/gps/horizon/service.definition.json`. Port number is 8080 for both services. 

Fixes issue #555 : CPU_PERCENT and GPS examples do not expose port. 