### PR TITLE
Issue #533 - Policy register documentation fix, adding business polic…

### DIFF
--- a/edge/evtstreams/cpu2evtstreams/PolicyRegister.md
+++ b/edge/evtstreams/cpu2evtstreams/PolicyRegister.md
@@ -82,7 +82,7 @@ hzn exchange service listpolicy IBM/ibm.cpu2evtstreams_1.4.3_amd64
 
 ### Deployment Policy 
 
-- Deployment Policy (sometimes called Deployment Policy) is what ties together Edge Nodes, Published Services, and the Policies defined for each of those, making it roughly analogous to the Deployment Patterns you have previously worked with.
+- Deployment Policy (sometimes called Business Policy) is what ties together Edge Nodes, Published Services, and the Policies defined for each of those, making it roughly analogous to the Deployment Patterns you have previously worked with.
 
 - Deployment Policy, like the other two Policy types, contains a set of `properties` and a set of `constraints`, but it contains other things as well. For example, it explicitly identifies the Service it will cause to be deployed onto Edge Nodes if negotiation is successful, in addition to configuration variable values, performing the equivalent function to the `-f horizon/userinput.json` clause of a Deployment Pattern `hzn register ...` command. The Deployment Policy approach for configuration values is more powerful because this operation can be performed centrally (no need to connect directly to the Edge Node).
 


### PR DESCRIPTION
The issue defined the change in Policy Registration Documentation which was 

What is the current documentation state?
Deployment Policy (sometimes called Deployment Policy) is what ties together Edge Nodes, Published...

Where is this stated?
https://github.com/open-horizon/examples/blob/master/edge/evtstreams/cpu2evtstreams/PolicyRegister.md#deployment-policy

What did I do to improve the statement?

According to the proposed solution I changed the statement to :

Deployment Policy (sometimes called Business Policy) is what ties together Edge Nodes, Published

Signed-off-by: Chandan Sharma(IBM) chandan.ireland@gmail.com