### PR TITLE
feat: 424 publish operator example to ppc64le

### DIFF
--- a/edge/services/nginx-operator/Makefile
+++ b/edge/services/nginx-operator/Makefile
@@ -41,8 +41,12 @@ publish-deployment-policy:
 	hzn exchange deployment addpolicy -f horizon/deployment.policy.json $(HZN_ORG_ID)/policy-$(SERVICE_NAME)_$(SERVICE_VERSION)
 
 # new target for icp exchange to run on startup to publish only
-publish-only: publish-service-overwrite publish-service-policy
-	hzn exchange pattern publish -f horizon/pattern.json
+publish-only:
+	ARCH=amd64 $(MAKE) publish-service-overwrite
+	ARCH=amd64 $(MAKE) publish-service-policy
+	ARCH=ppc64le $(MAKE) publish-service-overwrite
+	ARCH=ppc64le $(MAKE) publish-service-policy
+	hzn exchange pattern publish -f horizon/pattern-all-arches.json
 
 # This imports the variables from horizon/hzn.cfg. You can ignore these lines, but do not remove them.
 horizon/.hzn.json.tmp.mk: horizon/hzn.json

--- a/edge/services/nginx-operator/horizon/pattern-all-arches.json
+++ b/edge/services/nginx-operator/horizon/pattern-all-arches.json
@@ -1,0 +1,28 @@
+{
+  "name": "pattern-$SERVICE_NAME",
+  "label": "Edge $SERVICE_NAME Service Pattern for all architectures",
+  "description": "Pattern for $SERVICE_NAME",
+  "public": true,
+  "services": [
+    {
+      "serviceUrl": "$SERVICE_NAME",
+      "serviceOrgid": "$HZN_ORG_ID",
+      "serviceArch": "amd64",
+      "serviceVersions": [
+        {
+          "version": "$SERVICE_VERSION"
+        }
+      ]
+    },
+    {
+      "serviceUrl": "$SERVICE_NAME",
+      "serviceOrgid": "$HZN_ORG_ID",
+      "serviceArch": "ppc64le",
+      "serviceVersions": [
+        {
+          "version": "$SERVICE_VERSION"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
These modifications to the Makefile target `publish-only` will allow `exchangePublish.sh` to now load an exchange with the `ppc64le` arch version of the `ibm.nginx-operator` service.

