### PR TITLE
 Issue open-horizon#173 fix CWE-732: Insecure File Permissions

### DIFF
--- a/edge/evtstreams/sdr2evtstreams/train/label/main.go
+++ b/edge/evtstreams/sdr2evtstreams/train/label/main.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/open-horizon/examples/edge/msghub/sdr2msghub/train/watson/stt"
@@ -53,9 +52,9 @@ func main() {
 			hash := sha256.Sum256(audio)
 			name := base32.StdEncoding.EncodeToString(hash[:])
 			if totalText(transcript) > 20 {
-				err = ioutil.WriteFile("good/"+name+".raw", audio, 0644)
+				err = os.WriteFile("good/"+name+".raw", audio, 0644)
 			} else {
-				err = ioutil.WriteFile("nongood/"+name+".raw", audio, 0644)
+				err = os.WriteFile("nongood/"+name+".raw", audio, 0644)
 			}
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
When a resource is given a permissions setting that provides access to a wider range of actors than required, it could lead to the exposure of sensitive information, or the modification of that resource by unintended parties. This is especially dangerous when the resource is related to program configuration, execution or sensitive user data.